### PR TITLE
claude-mon: robust session classifier + token stats

### DIFF
--- a/client-py/claude-mon.py
+++ b/client-py/claude-mon.py
@@ -38,11 +38,35 @@ class ClaudeState(Enum):
 
 
 @dataclass(frozen=True)
+class TokenStats:
+    """Cumulative token usage for a session, plus active compute time."""
+
+    output: int  # sum of assistant.message.usage.output_tokens
+    input_fresh: int  # sum of assistant.message.usage.input_tokens (uncached)
+    input_cache_create: int  # sum of cache_creation_input_tokens
+    input_cache_read: int  # sum of cache_read_input_tokens (cheap, cache hit)
+    active_seconds: float  # sum of system/turn_duration.durationMs / 1000
+
+    @property
+    def input_total(self) -> int:
+        """What the model actually saw (summing the three input categories)."""
+        return self.input_fresh + self.input_cache_create + self.input_cache_read
+
+    @property
+    def throughput_tokens_per_s(self) -> float | None:
+        """Output tokens per second of active (compute) time — model throughput."""
+        if self.active_seconds <= 0:
+            return None
+        return self.output / self.active_seconds
+
+
+@dataclass(frozen=True)
 class ClaudeSession:
     path: str  # absolute project home (cwd of the claude process)
     name: str  # last component of path
     id: str  # session id (stem of the active JSONL file), "" if unknown
     state: ClaudeState
+    stats: TokenStats | None = None  # None if the jsonl is unreadable
 
 
 # =============================================================================
@@ -260,6 +284,26 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 #        result. Fix: grep a fresh jsonl for the tool_use/tool_result
 #        blocks and update the field names in the two helpers above.
 #
+#    C4. Token accounting — `assistant.message.usage`:
+#          Each assistant entry carries a `usage` object with at least:
+#            input_tokens                    int   — fresh (uncached) input
+#            cache_creation_input_tokens     int   — input written to prompt cache
+#            cache_read_input_tokens         int   — input served from cache
+#            output_tokens                   int   — generated tokens
+#          ("Total input" = sum of the three input categories; summing only
+#           `input_tokens` underreports by ~100× on cached sessions.)
+#          Also present but not currently used:
+#            service_tier / speed            str   — "standard" | "priority"
+#            cache_creation.ephemeral_{5m,1h}_input_tokens  int
+#            server_tool_use.{web_search,web_fetch}_requests int
+#            model                           str   — e.g. "claude-sonnet-4-6"
+#        Used in: TokenStats, _compute_token_stats.
+#        If the usage field is removed or renamed on an assistant entry,
+#        the entry contributes 0 to totals (defensive). Symptom:
+#        TokenStats show 0 output despite visible assistant activity.
+#        Fix: dump `.message.usage` of a recent assistant entry and realign
+#        the four field names in _compute_token_stats.
+#
 #    C3. Non-chronological file order:
 #          Entries are NOT necessarily in timestamp order within the jsonl.
 #          Observed on v2.1.114: a tool_result for tool_use id X can appear
@@ -306,6 +350,17 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 #        "informational". If a new turn-end subtype appears, add to the
 #        frozenset. Symptom: idle sessions permanently stuck on BUSY
 #        immediately after a tool call turn.
+#
+#    E2. `system/turn_duration.durationMs` is the turn's wall-clock compute
+#        time in MILLISECONDS (not ms, not seconds, not microseconds).
+#        Summed across all turn_duration entries it yields the session's
+#        total "active" / "thinking" time. Used in: TokenStats.active_seconds
+#        (divided by 1000), which in turn drives throughput_tokens_per_s.
+#        If the unit is renamed (e.g. durationSeconds) or the field moves,
+#        active_seconds stays at 0 and throughput reports as None ("—"
+#        in the CLI). Symptom: a session with plenty of output shows no
+#        t/s value. Fix: inspect a fresh turn_duration entry, update the
+#        two references in _compute_token_stats.
 #
 # F. Tool execution model
 #    F1. When Claude runs a tool that requires a subprocess (Bash, and
@@ -626,6 +681,52 @@ def _get_last_entry(path: Path | None) -> _LastEntry | None:
     )
 
 
+def _compute_token_stats(path: Path | None) -> TokenStats | None:
+    """Tally token usage and active compute time from a full jsonl transcript.
+
+    Reads the entire file (not just the tail): token totals are cumulative
+    over the whole session. Works in linear time; a 1 MB transcript is
+    sub-millisecond. See assumptions C4 and E2 for the fields we depend on.
+    """
+    if path is None:
+        return None
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    output = 0
+    input_fresh = 0
+    input_create = 0
+    input_read = 0
+    active_ms = 0
+    for raw in data.splitlines():
+        if not raw.strip():
+            continue
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        t = obj.get("type")
+        if t == "assistant":
+            usage = (obj.get("message") or {}).get("usage")
+            if isinstance(usage, dict):
+                output += int(usage.get("output_tokens") or 0)
+                input_fresh += int(usage.get("input_tokens") or 0)
+                input_create += int(usage.get("cache_creation_input_tokens") or 0)
+                input_read += int(usage.get("cache_read_input_tokens") or 0)
+        elif t == "system" and obj.get("subtype") == "turn_duration":
+            d = obj.get("durationMs")
+            if isinstance(d, (int, float)):
+                active_ms += int(d)
+    return TokenStats(
+        output=output,
+        input_fresh=input_fresh,
+        input_cache_create=input_create,
+        input_cache_read=input_read,
+        active_seconds=active_ms / 1000.0,
+    )
+
+
 def _classify(pid: int, entry: _LastEntry | None) -> ClaudeState:
     if entry is None:
         return ClaudeState.IDLE
@@ -717,6 +818,7 @@ def get_sessions() -> list[ClaudeSession]:
                 name=os.path.basename(p.cwd.rstrip("/")),
                 id=sid,
                 state=_classify(p.pid, entry),
+                stats=_compute_token_stats(p.jsonl),
             )
         )
     return sessions
@@ -730,6 +832,17 @@ def get_state_counts(
     for s in sessions or get_sessions():
         counts[s.state] += 1
     return counts
+
+
+def _humanize_count(n: int) -> str:
+    """Short human-readable integer: 12345 → '12.3K', 4_567_890 → '4.6M'."""
+    if n < 1000:
+        return str(n)
+    if n < 1_000_000:
+        return f"{n / 1000:.1f}K"
+    if n < 1_000_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    return f"{n / 1_000_000_000:.1f}G"
 
 
 def main() -> int:
@@ -747,9 +860,16 @@ def main() -> int:
     print()
     for s in sessions:
         state_colored = _colorize(f" {s.state:^6} ", s.state)
-        sid = s.id
-        sid = sid.split("-")[-1]
-        print(f"{sid} {state_colored} {s.name}")
+        sid = s.id.split("-")[-1]
+        if s.stats is not None:
+            out_s = _humanize_count(s.stats.output)
+            in_s = _humanize_count(s.stats.input_total)
+            tput = s.stats.throughput_tokens_per_s
+            tput_s = f"{tput:.0f} t/s" if tput is not None else "—"
+            metrics = f"  out:{out_s:>6}  in:{in_s:>6}  {tput_s:>7}"
+        else:
+            metrics = ""
+        print(f"{sid} {state_colored} {s.name:<28}{metrics}")
     return 0
 
 

--- a/client-py/claude-mon.py
+++ b/client-py/claude-mon.py
@@ -130,6 +130,12 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 #     (socat from /sandbox, editors from Ctrl-G) predate the tool_use and
 #     are correctly ignored.
 #
+# Turn-end override: Claude Code appends `system/turn_duration` and
+# `system/away_summary` entries once a turn has completed. If one of
+# these appears in the tail after the last user/assistant entry, the
+# turn has ended regardless of whether that last entry was a `user`
+# tool_result (which would otherwise look mid-turn) → IDLE.
+#
 # We do not sample over time — no CPU ticks, no mtime deltas, no grace
 # windows. Transitions appear with whatever latency the JSONL and /proc
 # themselves exhibit, which is the minimum achievable by a passive monitor.
@@ -141,6 +147,23 @@ class _LastEntry:
     kind: str  # "user" or "assistant"
     has_tool_use: bool
     timestamp: float | None  # epoch seconds, None if missing/unparseable
+    turn_ended: bool  # system/turn_duration or away_summary seen after this entry
+
+
+# System subtypes emitted by Claude Code that mean the turn has wrapped up.
+# Their presence after the last user/assistant entry forces IDLE.
+_TURN_END_SUBTYPES = frozenset({"turn_duration", "away_summary"})
+
+# Slash-command audit markers: Claude Code writes these as type="user"
+# entries, but they are *not* user prompts — they are internal records of
+# commands like /clear, /compact, etc. Including them in the tail scan
+# would misclassify a freshly /clear'd session as BUSY.
+_INTERNAL_USER_PREFIXES = (
+    "<command-name>",
+    "<local-command-caveat>",
+    "<local-command-stdout>",
+    "<local-command-stderr>",
+)
 
 
 @dataclass
@@ -226,7 +249,9 @@ def _newest_jsonl(project_dir: Path) -> Path | None:
     return best
 
 
-def _find_active_jsonl(cwd: str, session_id_hint: str | None, solo: bool) -> Path | None:
+def _find_active_jsonl(
+    cwd: str, session_id_hint: str | None, solo: bool
+) -> Path | None:
     """Resolve a probe's live JSONL transcript.
 
     - solo probe for the cwd → newest jsonl in the project_dir. This is
@@ -260,18 +285,6 @@ def _parse_timestamp(s: str | None) -> float | None:
         return None
 
 
-# Slash-command audit markers: Claude Code writes these as type="user"
-# entries, but they are *not* user prompts — they are internal records of
-# commands like /clear, /compact, etc. Including them in the tail scan
-# would misclassify a freshly /clear'd session as BUSY.
-_INTERNAL_USER_PREFIXES = (
-    "<command-name>",
-    "<local-command-caveat>",
-    "<local-command-stdout>",
-    "<local-command-stderr>",
-)
-
-
 def _is_internal_user_content(content) -> bool:
     if not isinstance(content, str):
         return False
@@ -291,12 +304,16 @@ def _get_last_entry(path: Path | None) -> _LastEntry | None:
             chunk = f.read()
     except OSError:
         return None
+    turn_ended = False
     for raw in reversed([ln for ln in chunk.splitlines() if ln.strip()]):
         try:
             obj = json.loads(raw)
         except json.JSONDecodeError:
             continue
         kind = obj.get("type")
+        if kind == "system" and obj.get("subtype") in _TURN_END_SUBTYPES:
+            turn_ended = True
+            continue
         if kind not in ("user", "assistant"):
             continue
         msg = obj.get("message") or {}
@@ -310,12 +327,15 @@ def _get_last_entry(path: Path | None) -> _LastEntry | None:
             kind=kind,
             has_tool_use=has_tool_use,
             timestamp=_parse_timestamp(obj.get("timestamp")),
+            turn_ended=turn_ended,
         )
     return None
 
 
 def _classify(pid: int, entry: _LastEntry | None) -> ClaudeState:
     if entry is None:
+        return ClaudeState.IDLE
+    if entry.turn_ended:
         return ClaudeState.IDLE
     if entry.kind == "user":
         return ClaudeState.BUSY
@@ -379,11 +399,15 @@ def get_sessions() -> list[ClaudeSession]:
         solo = cwd_counts[p.cwd] == 1
         p.jsonl = _find_active_jsonl(p.cwd, p.session_id_hint, solo)
         entry = _get_last_entry(p.jsonl)
+        if p.jsonl is not None:
+            sid = p.jsonl.stem
+        else:
+            sid = p.session_id_hint or ""
         sessions.append(
             ClaudeSession(
                 path=p.cwd,
                 name=os.path.basename(p.cwd.rstrip("/")),
-                id=p.jsonl.stem if p.jsonl is not None else "",
+                id=sid,
                 state=_classify(p.pid, entry),
             )
         )
@@ -415,8 +439,9 @@ def main() -> int:
     print()
     for s in sessions:
         state_colored = _colorize(f" {s.state:^6} ", s.state)
-        print(f"{s.id[-6:]} {state_colored} {s.name}")
-        # print(f"{s.id} {state_colored} {s.name}")
+        sid = s.id
+        sid = sid.split("-")[-1]
+        print(f"{sid} {state_colored} {s.name}")
     return 0
 
 

--- a/client-py/claude-mon.py
+++ b/client-py/claude-mon.py
@@ -146,21 +146,29 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 #   * Refinement: "ASKING" is ambiguous between (a) permission modal waiting
 #     for the user, and (b) tool was approved and is now executing (or
 #     already executed — in-process tools like Read/Edit/Grep leave no
-#     /proc trace and return almost instantly). We disambiguate in two
+#     /proc trace and return almost instantly). We disambiguate in three
 #     steps, in order:
 #
-#       Step 1 (transcript): does the tail already contain a `tool_result`
-#         whose `tool_use_id` matches one of the `tool_use.id`s in the last
-#         assistant entry? If yes, the tool has returned → BUSY. This
-#         catches the in-process-tool case, which has no subprocess to
-#         detect via /proc.
+#       Step 1 (parent transcript): does the tail already contain a
+#         `tool_result` whose `tool_use_id` matches one of the `tool_use.id`s
+#         in the last assistant entry? If yes, the tool has returned → BUSY.
+#         This catches the fast in-process-tool case, which has no
+#         subprocess to detect via /proc.
 #
-#       Step 2 (/proc): if no matching tool_result yet, check child
-#         subprocess start times against the turn-boundary timestamp (the
-#         PREVIOUS u/a entry's timestamp, not the current tool_use entry's
-#         — Claude spawns the subprocess ~hundreds of ms BEFORE the tool_use
-#         jsonl write completes, so comparing to the tool_use ts itself
-#         misses the child):
+#       Step 2 (subagent transcripts): is there a live sidechain jsonl
+#         under <project_dir>/<sid>/subagents/ whose last u/a entry is
+#         non-terminal (subagent still iterating)? If yes → BUSY. This
+#         catches long-running Agent tools whose top-level tool_result
+#         hasn't landed yet. Subagents are in-process like other fast
+#         in-process tools, but runs can take minutes, so Step 1 alone
+#         leaves too large an ASKING window. See assumption I.
+#
+#       Step 3 (/proc): if no matching tool_result and no active subagent,
+#         check child subprocess start times against the turn-boundary
+#         timestamp (the PREVIOUS u/a entry's timestamp, not the current
+#         tool_use entry's — Claude spawns the subprocess ~hundreds of ms
+#         BEFORE the tool_use jsonl write completes, so comparing to the
+#         tool_use ts itself misses the child):
 #           - any child spawned AFTER the previous u/a entry → BUSY;
 #           - no such child → ASKING stays.
 #         This uses /proc/<cpid>/stat field 22 (`starttime` in clock ticks
@@ -210,6 +218,8 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 #      and what breaks if Claude switches to an orchestrator model.
 #   G. Process identity — the 7-byte comm "claude" check.
 #   H. /proc schema — field offsets and the Linux constants we rely on.
+#   I. Subagent sidechain transcripts — live per-Agent jsonl under
+#      <project_dir>/<sid>/subagents/agent-*.jsonl and the terminal rule.
 #
 # Details:
 #
@@ -412,6 +422,52 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 #        Used in: _boot_time.
 #    H3. SC_CLK_TCK gives ticks-per-second (almost always 100).
 #        Used in: _CLK_TCK module constant.
+#
+# I. Subagent sidechain transcripts
+#    I1. When Claude runs an Agent tool, it writes a live sidechain
+#        transcript at:
+#            ~/.claude/projects/<encoded-cwd>/<session-id>/subagents/agent-<agentId>.jsonl
+#        Entries carry {isSidechain: true, sessionId: <parent sid>,
+#        agentId: <subagent id>, type/message/timestamp: same shape as
+#        parent entries}. The subagent's first entry is a `user` with the
+#        initial prompt, timestamp within a few ms of the parent's Agent
+#        tool_use entry.
+#        Used in: _has_active_subagent, which globs agent-*.jsonl under
+#        <project_dir>/<sid>/subagents/ and checks each live file's tail.
+#        This is the only intrinsic signal that an in-process Agent is
+#        currently running — the parent transcript merely shows an
+#        unresolved tool_use for minutes. Without this step the classifier
+#        reports ASKING for the whole subagent run (Read/Edit/Grep are
+#        sub-second so the assumption F1 ASKING window is invisible, but
+#        Agent is not).
+#        If Claude Code moves or renames the subagents directory (e.g.
+#        "sidechains/", or flattens files alongside the parent jsonl),
+#        _has_active_subagent silently returns False. Symptom: multi-minute
+#        Agent runs flip to ASKING until every sibling tool_result lands.
+#        Fix: update the sub_dir path in _has_active_subagent.
+#
+#    I2. Subagent transcripts contain NO `system/turn_duration` or
+#        `away_summary` entries (unlike parent transcripts). Subagent
+#        terminal state therefore cannot use the turn_ended flag. Instead:
+#        the subagent is considered done iff its last qualifying u/a entry
+#        is an `assistant` message with NO tool_use content blocks — this
+#        is the final text answer the subagent returns to the parent.
+#        Anything else (user tool_result, or assistant with tool_use) means
+#        the subagent is mid-iteration. Symmetric with the top-level
+#        assistant-without-tool_use → IDLE rule.
+#        If a future version starts emitting a turn-end system marker in
+#        subagent jsonls, we can tighten this to also consume that marker,
+#        but the current rule is still correct.
+#
+#    I3. Scoping by mtime: _has_active_subagent compares each file's mtime
+#        against the parent's `prev_timestamp` (the current turn boundary)
+#        and skips subagents from earlier turns. Every such subagent has
+#        long since finished writing, so its mtime is strictly less than
+#        any post-turn-boundary write. This is a pure performance filter;
+#        the classification signal remains the content of the tail.
+#        If Claude Code ever touches old subagent jsonls (e.g. for log
+#        rotation or batched flushes), the filter could admit stale files,
+#        which is harmless — the terminal-rule content check still decides.
 # -----------------------------------------------------------------------------
 
 
@@ -727,7 +783,42 @@ def _compute_token_stats(path: Path | None) -> TokenStats | None:
     )
 
 
-def _classify(pid: int, entry: _LastEntry | None) -> ClaudeState:
+def _has_active_subagent(jsonl: Path, threshold: float | None) -> bool:
+    """True if any subagent transcript for this session is mid-iteration.
+
+    Terminal rule (per assumption I2): last qualifying u/a entry is
+    `assistant` with no tool_use → subagent returned. Anything else (user
+    tool_result, or assistant with tool_use) = still iterating → BUSY.
+
+    Scoped by file mtime vs `threshold` (parent's prev turn boundary) to
+    skip subagents from earlier turns, which are all terminal by now.
+    """
+    sub_dir = jsonl.parent / jsonl.stem / "subagents"
+    if not sub_dir.is_dir():
+        return False
+    try:
+        candidates = list(sub_dir.glob("agent-*.jsonl"))
+    except OSError:
+        return False
+    for f in candidates:
+        try:
+            mtime = f.stat().st_mtime
+        except OSError:
+            continue
+        if threshold is not None and mtime < threshold:
+            continue
+        last = _get_last_entry(f)
+        if last is None:
+            continue
+        if last.kind == "assistant" and not last.has_tool_use:
+            continue  # subagent returned its final answer
+        return True
+    return False
+
+
+def _classify(
+    pid: int, entry: _LastEntry | None, jsonl: Path | None = None
+) -> ClaudeState:
     if entry is None:
         return ClaudeState.IDLE
     if entry.turn_ended:
@@ -744,7 +835,13 @@ def _classify(pid: int, entry: _LastEntry | None) -> ClaudeState:
     #     and Claude is processing the result → BUSY.
     if entry.tool_resolved:
         return ClaudeState.BUSY
-    # (b) Otherwise check /proc for a subprocess spawned for this turn.
+    # (b) A long-running Agent runs in-process so has no /proc child, and
+    #     its parent tool_result may not land for minutes (parallel-tool
+    #     batches are gated on the slowest sibling). Check sidechain
+    #     transcripts for live subagent activity.
+    if jsonl is not None and _has_active_subagent(jsonl, entry.prev_timestamp):
+        return ClaudeState.BUSY
+    # (c) Otherwise check /proc for a subprocess spawned for this turn.
     #     Reference time: the PREVIOUS u/a entry's timestamp, not this one's.
     #     Empirically Claude spawns the subprocess a few hundred ms BEFORE
     #     the tool_use entry's jsonl write, so comparing to entry.timestamp
@@ -817,7 +914,7 @@ def get_sessions() -> list[ClaudeSession]:
                 path=p.cwd,
                 name=os.path.basename(p.cwd.rstrip("/")),
                 id=sid,
-                state=_classify(p.pid, entry),
+                state=_classify(p.pid, entry, p.jsonl),
                 stats=_compute_token_stats(p.jsonl),
             )
         )

--- a/client-py/claude-mon.py
+++ b/client-py/claude-mon.py
@@ -120,15 +120,29 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 #   `assistant` without `tool_use`            | IDLE
 #
 #   * Refinement: "ASKING" is ambiguous between (a) permission modal waiting
-#     for the user, and (b) tool was approved and is now executing. We
-#     disambiguate by checking the start time of claude's children:
-#       - any child spawned AFTER the tool_use entry's timestamp
-#         → tool is running → BUSY;
-#       - no such child → ASKING stays.
-#     This uses /proc/<cpid>/stat field 22 (`starttime` in clock ticks
-#     since boot) plus /proc/stat `btime` (boot epoch). Persistent helpers
-#     (socat from /sandbox, editors from Ctrl-G) predate the tool_use and
-#     are correctly ignored.
+#     for the user, and (b) tool was approved and is now executing (or
+#     already executed — in-process tools like Read/Edit/Grep leave no
+#     /proc trace and return almost instantly). We disambiguate in two
+#     steps, in order:
+#
+#       Step 1 (transcript): does the tail already contain a `tool_result`
+#         whose `tool_use_id` matches one of the `tool_use.id`s in the last
+#         assistant entry? If yes, the tool has returned → BUSY. This
+#         catches the in-process-tool case, which has no subprocess to
+#         detect via /proc.
+#
+#       Step 2 (/proc): if no matching tool_result yet, check child
+#         subprocess start times against the turn-boundary timestamp (the
+#         PREVIOUS u/a entry's timestamp, not the current tool_use entry's
+#         — Claude spawns the subprocess ~hundreds of ms BEFORE the tool_use
+#         jsonl write completes, so comparing to the tool_use ts itself
+#         misses the child):
+#           - any child spawned AFTER the previous u/a entry → BUSY;
+#           - no such child → ASKING stays.
+#         This uses /proc/<cpid>/stat field 22 (`starttime` in clock ticks
+#         since boot) plus /proc/stat `btime` (boot epoch). Persistent
+#         helpers (socat from /sandbox, editors from Ctrl-G) predate the
+#         previous turn boundary and are correctly ignored.
 #
 # Turn-end override: Claude Code appends `system/turn_duration` and
 # `system/away_summary` entries once a turn has completed. If one of
@@ -229,6 +243,40 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 #        and every tool_use becomes invisible → everything classifies as IDLE
 #        or BUSY (never ASKING). Symptom: permission menus never show ASKING.
 #
+#    C2. Tool-use ↔ tool-result correlation:
+#          `assistant` content blocks of type "tool_use" carry {id: str, name, ...}.
+#          `user` content blocks of type "tool_result" carry {tool_use_id: str, ...}
+#          referencing the id of the tool_use they satisfy.
+#        Used in: _collect_tool_use_ids, _has_matching_tool_result, _classify's
+#        Step 1 fast-path for "tool already returned → BUSY".
+#        This is the only way to detect completion of an IN-PROCESS tool
+#        (Read/Edit/Grep/Glob/Write/TodoWrite), which leaves no /proc
+#        signal. If the field names change (e.g. "id"→"uuid" on the tool_use
+#        side, or "tool_use_id"→"tool_call_id" on the tool_result side),
+#        the fast-path silently stops firing and in-process tools revert
+#        to the F1 limitation (brief ASKING during execution, then BUSY
+#        when the next assistant turn lands). Symptom: a session stays on
+#        ASKING indefinitely while Claude is clearly processing a Read/Edit
+#        result. Fix: grep a fresh jsonl for the tool_use/tool_result
+#        blocks and update the field names in the two helpers above.
+#
+#    C3. Non-chronological file order:
+#          Entries are NOT necessarily in timestamp order within the jsonl.
+#          Observed on v2.1.114: a tool_result for tool_use id X can appear
+#          several file-lines EARLIER than the tool_use that produced X.
+#          Claude Code evidently flushes buffered entries in a non-strict
+#          order during a multi-step turn.
+#        Used in: _has_matching_tool_result scans the WHOLE parsed chunk
+#        (not just entries before/after `last_idx`) and matches by
+#        tool_use_id, which is order-independent.
+#        The reverse-walk for `last_idx` also uses file position, not
+#        timestamp — so the "last entry" we classify on is the file-last
+#        one, which is what Claude Code most recently wrote to disk (and
+#        therefore what the live UI is currently displaying as the tail).
+#        If Claude Code switches to strict chronological writes, nothing
+#        breaks; the file-order heuristic just happens to coincide with
+#        timestamp-order.
+#
 # D. Slash-command audit records (internal user entries to skip)
 #    D1. When the user runs a slash command, Claude Code appends user-type
 #        entries whose content is a STRING starting with one of:
@@ -262,13 +310,26 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 # F. Tool execution model
 #    F1. When Claude runs a tool that requires a subprocess (Bash, and
 #        anything delegating to one), it spawns a DIRECT child of the claude
-#        PID, and that child's start time is AFTER the `assistant` entry
-#        containing the tool_use block was written.
-#        Used in: _child_start_times + _classify's refinement loop.
+#        PID. The child's start time is usually slightly BEFORE the jsonl
+#        write of the corresponding `tool_use` entry completes — observed
+#        ~100–200 ms ahead of the entry.timestamp on v2.1.114. We therefore
+#        do NOT compare child.start to the current tool_use entry's
+#        timestamp (that test rejects the child and stays stuck on ASKING);
+#        instead we compare to the PREVIOUS u/a entry's timestamp, which is
+#        the true turn boundary and is always well before any current-turn
+#        tool spawn.
+#        Used in: _child_start_times + _classify's Step 2 refinement,
+#        _LastEntry.prev_timestamp, _get_last_entry's two-entry walk.
 #        In-process tools (Read, Edit, Grep, Glob, Write, TodoWrite, etc.)
-#        do NOT spawn a child; we can't distinguish "permission pending"
-#        from "in-process tool executing" for those — they briefly show as
-#        ASKING during execution. Accepted limitation.
+#        do NOT spawn a child, so this /proc-based check alone cannot
+#        distinguish "permission pending" from "in-process tool executing".
+#        That gap is now closed by the transcript-based fast path at
+#        Step 1 of _classify (see assumption C2): once a matching
+#        tool_result lands in the jsonl, the classifier reports BUSY
+#        regardless of /proc signals. The /proc check here handles the
+#        pre-tool_result window of subprocess-based tools (Bash et al.)
+#        where the child is already running but no tool_result has been
+#        written yet.
 #        If Claude Code switches Bash to an in-process library, or starts
 #        using an orchestrator process (so claude's direct child becomes a
 #        persistent helper instead of the tool itself), the refinement
@@ -276,6 +337,10 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 #        every session pins to BUSY (if the orchestrator is long-lived).
 #        Fix: walk the process tree recursively, or match the new helper
 #        by comm and look one level deeper.
+#        If the write-vs-spawn ordering changes so tool children appear
+#        AFTER the previous turn boundary by a large margin (e.g. Claude
+#        batches writes seconds later), consider a grace window on the
+#        threshold or switching back to entry.timestamp - epsilon.
 #
 # G. Process identity
 #    G1. Claude Code's `/proc/<pid>/comm` is literally the 7-byte string
@@ -300,7 +365,9 @@ class _LastEntry:
     kind: str  # "user" or "assistant"
     has_tool_use: bool
     timestamp: float | None  # epoch seconds, None if missing/unparseable
+    prev_timestamp: float | None  # ts of the u/a entry BEFORE this one (turn boundary)
     turn_ended: bool  # system/turn_duration or away_summary seen after this entry
+    tool_resolved: bool  # a matching tool_result exists for this entry's tool_use(s)
 
 
 # System subtypes emitted by Claude Code that mean the turn has wrapped up.
@@ -445,6 +512,51 @@ def _is_internal_user_content(content) -> bool:
     return any(stripped.startswith(p) for p in _INTERNAL_USER_PREFIXES)
 
 
+def _is_qualifying_ua(obj: dict) -> bool:
+    """True if `obj` is a user/assistant entry the classifier should act on."""
+    kind = obj.get("type")
+    if kind not in ("user", "assistant"):
+        return False
+    if kind == "user":
+        msg = obj.get("message") or {}
+        if _is_internal_user_content(msg.get("content") or []):
+            return False
+    return True
+
+
+def _collect_tool_use_ids(content) -> set[str]:
+    if not isinstance(content, list):
+        return set()
+    ids: set[str] = set()
+    for c in content:
+        if isinstance(c, dict) and c.get("type") == "tool_use":
+            tid = c.get("id")
+            if isinstance(tid, str):
+                ids.add(tid)
+    return ids
+
+
+def _has_matching_tool_result(parsed: list[dict], tool_use_ids: set[str]) -> bool:
+    """True if any user entry in `parsed` carries a tool_result for one of `tool_use_ids`."""
+    if not tool_use_ids:
+        return False
+    for obj in parsed:
+        if obj.get("type") != "user":
+            continue
+        msg = obj.get("message") or {}
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for c in content:
+            if (
+                isinstance(c, dict)
+                and c.get("type") == "tool_result"
+                and c.get("tool_use_id") in tool_use_ids
+            ):
+                return True
+    return False
+
+
 def _get_last_entry(path: Path | None) -> _LastEntry | None:
     if path is None:
         return None
@@ -457,32 +569,61 @@ def _get_last_entry(path: Path | None) -> _LastEntry | None:
             chunk = f.read()
     except OSError:
         return None
-    turn_ended = False
-    for raw in reversed([ln for ln in chunk.splitlines() if ln.strip()]):
+    parsed: list[dict] = []
+    for raw in chunk.splitlines():
+        if not raw.strip():
+            continue
         try:
-            obj = json.loads(raw)
+            parsed.append(json.loads(raw))
         except json.JSONDecodeError:
             continue
-        kind = obj.get("type")
-        if kind == "system" and obj.get("subtype") in _TURN_END_SUBTYPES:
+    if not parsed:
+        return None
+
+    # Walk backward to find the "last" qualifying u/a entry. Along the way,
+    # flip turn_ended if we see a turn-end system subtype after that entry.
+    turn_ended = False
+    last_idx: int | None = None
+    for i in range(len(parsed) - 1, -1, -1):
+        obj = parsed[i]
+        if last_idx is None and obj.get("type") == "system" and obj.get("subtype") in _TURN_END_SUBTYPES:
             turn_ended = True
             continue
-        if kind not in ("user", "assistant"):
-            continue
-        msg = obj.get("message") or {}
-        content = msg.get("content") or []
-        if kind == "user" and _is_internal_user_content(content):
-            continue
-        has_tool_use = any(
-            isinstance(c, dict) and c.get("type") == "tool_use" for c in content
-        )
-        return _LastEntry(
-            kind=kind,
-            has_tool_use=has_tool_use,
-            timestamp=_parse_timestamp(obj.get("timestamp")),
-            turn_ended=turn_ended,
-        )
-    return None
+        if _is_qualifying_ua(obj):
+            last_idx = i
+            break
+    if last_idx is None:
+        return None
+
+    last_obj = parsed[last_idx]
+    last_content = (last_obj.get("message") or {}).get("content") or []
+    has_tool_use = any(
+        isinstance(c, dict) and c.get("type") == "tool_use" for c in last_content
+    )
+
+    # Previous u/a entry (turn boundary for the child-spawn threshold).
+    prev_timestamp: float | None = None
+    for j in range(last_idx - 1, -1, -1):
+        obj = parsed[j]
+        if _is_qualifying_ua(obj):
+            prev_timestamp = _parse_timestamp(obj.get("timestamp"))
+            break
+
+    # Has any tool_result matching a tool_use in the last entry already been
+    # written? If so, the tool was approved+executed and Claude is processing
+    # — even for in-process tools that never spawn a subprocess.
+    tool_resolved = has_tool_use and _has_matching_tool_result(
+        parsed, _collect_tool_use_ids(last_content)
+    )
+
+    return _LastEntry(
+        kind=last_obj.get("type"),
+        has_tool_use=has_tool_use,
+        timestamp=_parse_timestamp(last_obj.get("timestamp")),
+        prev_timestamp=prev_timestamp,
+        turn_ended=turn_ended,
+        tool_resolved=tool_resolved,
+    )
 
 
 def _classify(pid: int, entry: _LastEntry | None) -> ClaudeState:
@@ -496,9 +637,23 @@ def _classify(pid: int, entry: _LastEntry | None) -> ClaudeState:
     if not entry.has_tool_use:
         return ClaudeState.IDLE
     # tool_use present: disambiguate "permission pending" vs "tool running".
-    if entry.timestamp is not None:
+    # (a) If a tool_result matching this entry's tool_use(s) is already in
+    #     the transcript, the tool was approved + executed (possibly an
+    #     in-process tool like Read/Edit/Grep that leaves no /proc signal),
+    #     and Claude is processing the result → BUSY.
+    if entry.tool_resolved:
+        return ClaudeState.BUSY
+    # (b) Otherwise check /proc for a subprocess spawned for this turn.
+    #     Reference time: the PREVIOUS u/a entry's timestamp, not this one's.
+    #     Empirically Claude spawns the subprocess a few hundred ms BEFORE
+    #     the tool_use entry's jsonl write, so comparing to entry.timestamp
+    #     misses the child. Any child spawned after the previous turn
+    #     boundary is a candidate tool-execution child. Falls back to
+    #     entry.timestamp when there's only one entry in the scanned tail.
+    threshold = entry.prev_timestamp if entry.prev_timestamp is not None else entry.timestamp
+    if threshold is not None:
         for start in _child_start_times(pid):
-            if start > entry.timestamp:
+            if start > threshold:
                 return ClaudeState.BUSY
     return ClaudeState.ASKING
 

--- a/client-py/claude-mon.py
+++ b/client-py/claude-mon.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""List active Claude sessions for the current user with their state.
+
+As a CLI, prints one tab-separated line per session: "<name>\t<id>\t<state>".
+
+As a module, provides:
+  - ClaudeState:          enum of possible session states
+  - ClaudeSession:        dataclass describing one live session
+  - get_sessions():       list[ClaudeSession] for all live claude processes
+"""
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+SESSIONS_DIR = Path.home() / ".claude" / "sessions"
+PROJECTS_DIR = Path.home() / ".claude" / "projects"
+
+SAMPLE_SECONDS = 1.5
+# CPU ticks accumulated by the claude process during the sample window that
+# we treat as "this process is actively doing work". Node.js idle background
+# activity (GC, timers) can produce 1–3 ticks in 1.5s; 20 (~13% CPU) clears it.
+CPU_TICK_THRESHOLD = 20
+# If the session's JSONL was touched within this many seconds, assume the
+# process is still mid-operation even if our brief sample caught a lull.
+RECENT_WRITE_SECONDS = 3.0
+TAIL_BYTES = 64 * 1024
+
+
+# =============================================================================
+# Claude states and session
+# =============================================================================
+
+
+class ClaudeState(Enum):
+    BUSY = "busy"
+    ASKING = "asking"  # Awaiting user answer to menu
+    IDLE = "idle"  # Awaiting prompt
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass(frozen=True)
+class ClaudeSession:
+    path: str  # absolute project home (cwd of the claude process)
+    name: str  # last component of path
+    id: str  # session id (stem of the active JSONL file), "" if unknown
+    state: ClaudeState
+
+
+# =============================================================================
+# ANSI colors
+# =============================================================================
+
+# --- Step 1: ANSI palette ------------------------------------------------
+# Named SGR codes. Only the basic 16-color codes are used here because `watch`
+# (and some other viewers) silently drop 256-color sequences like 48;5;208.
+
+_ANSI_RESET = "\x1b[0m"
+
+# Foregrounds
+_FG_BLACK = "\x1b[30m"
+_FG_WHITE = "\x1b[97m"
+_FG_GREY = "\x1b[90m"  # "bright black" foreground = mid-dark grey
+
+# Backgrounds
+_BG_BLACK = "\x1b[40m"
+_BG_RED = "\x1b[41m"
+_BG_GREEN = "\x1b[42m"
+_BG_YELLOW = "\x1b[43m"
+_BG_BLUE = "\x1b[44m"
+_BG_GREY = "\x1b[100m"  # "bright black" = mid-dark grey, standard 16-color
+
+# Effects (ANSI blink applies to the foreground only)
+_FX_BLINK = "\x1b[5m"
+_FX_BOLD = "\x1b[1m"
+
+# --- Step 2: per-state style ---------------------------------------------
+# Each entry is the concatenated SGR prefix applied before the text. Tweak
+# here to re-skin a state — e.g. `ClaudeState.AWAITING_PROMPT: _FG_WHITE + _BG_RED`.
+_STATE_STYLE: dict[ClaudeState, str] = {
+    ClaudeState.BUSY: _FG_BLACK + _BG_RED,
+    ClaudeState.ASKING: _FG_BLACK + _BG_YELLOW + _FX_BLINK,
+    ClaudeState.IDLE: _FG_BLACK + _BG_GREEN,
+}
+
+
+def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
+    """Wrap `text` in the ANSI style defined for `state`."""
+    if not doit:
+        return f"{_BG_BLACK}{_FG_GREY}{text}{_ANSI_RESET}"
+    else:
+        return f"{_STATE_STYLE[state]}{text}{_ANSI_RESET}"
+
+
+# =============================================================================
+# Probing
+# =============================================================================
+#
+# -----------------------------------------------------------------------------
+# STRATEGY — how we find ACTIVE sessions
+# -----------------------------------------------------------------------------
+# Claude Code does not expose a public "list my sessions" API, so we reverse
+# the problem by combining two filesystem sources plus /proc:
+#
+#   1. ~/.claude/sessions/<pid>.json
+#        Each running `claude` process drops a small JSON file here recording
+#        { "pid": ..., "cwd": ..., "sessionId": ..., ... }. This is our
+#        ENUMERATION source: it tells us which PIDs *claim* to be Claude Code
+#        sessions, the working directory each was launched from, and the
+#        session id to use as a direct pointer into (3). See
+#        `_load_session_probes`.
+#
+#   2. /proc/<pid>  (Linux only)
+#        The sessions file can be stale (process died without cleanup, PID
+#        was recycled, another user's PID collides). So for every candidate
+#        we VERIFY via /proc that:
+#           - the PID still exists,
+#           - its comm is literally "claude",
+#           - it is owned by the current UID.
+#        That is `_is_process_claude`. Only survivors count as "active".
+#
+#   3. ~/.claude/projects/<encoded-cwd>/*.jsonl
+#        Claude Code writes a JSONL transcript per session here, where
+#        <encoded-cwd> is the absolute cwd with "/" replaced by "-". To map
+#        a PID to its OWN transcript (crucial when two sessions share a cwd
+#        and therefore share this project_dir) we use the sessionId from
+#        sessions/<pid>.json: the live jsonl is <project_dir>/<sessionId>.jsonl.
+#        If the hint is missing or its file doesn't exist (e.g. /clear just
+#        rotated the id and the sessions file hasn't caught up yet) we fall
+#        back to the newest .jsonl in the project_dir. See `_find_active_jsonl`.
+#
+# We do NOT dedupe by cwd: concurrent sessions in the same directory are
+# legitimate and each has its own pid + sessionId, which the hint-based
+# resolver keeps separate.
+#
+# -----------------------------------------------------------------------------
+# STRATEGY — how we classify each active session into BUSY / ASKING / IDLE
+# -----------------------------------------------------------------------------
+# We don't have an IPC hook into the running `claude` process, so we infer
+# state from externally-observable signals. The classifier runs in two layers:
+#
+#   Layer A — "is it BUSY right now?"  (see `_is_busy`)
+#     We take two snapshots SAMPLE_SECONDS apart and declare BUSY if ANY of:
+#       (a) The active JSONL's (size, mtime) changed between the two samples
+#           → the process is actively appending turns / tool results.
+#       (b) The JSONL's mtime is within RECENT_WRITE_SECONDS of "now"
+#           → it wrote very recently; our 1.5s window may have caught a lull
+#             between a tool result and the next assistant turn.
+#       (c) The process has at least one child in /proc whose state is R
+#           (running) or D (uninterruptible sleep / I/O)
+#           → a Bash/tool subprocess is actively burning CPU or doing I/O.
+#           We deliberately ignore children in state S: those are sleeping
+#           on a pipe/poll/read (Ctrl-G editor, persistent helpers like the
+#           socat processes spawned by /sandbox, etc.) and don't represent
+#           work Claude is waiting on.
+#       (d) CPU ticks accumulated by the process during the sample window
+#           exceed CPU_TICK_THRESHOLD
+#           → Node.js idle bookkeeping (GC, timers) produces only a handful
+#             of ticks; anything well above that means real work (token
+#             streaming, JSON parsing, tool dispatch, ...).
+#     Any single signal is enough; they are complementary so we can catch
+#     both "writing to disk" work and "waiting on a child tool" work.
+#
+#   Layer B — "if not busy, is it ASKING or IDLE?"  (see `_classify`)
+#     When idle-looking, we tail the active JSONL and inspect the LAST
+#     user/assistant entry:
+#       - No parseable entry yet               → IDLE (fresh/blank session).
+#       - Last entry is `assistant` with a     → ASKING. Claude has emitted
+#         `tool_use` content block               a tool call and is waiting
+#                                                for the user to approve it
+#                                                via the permission menu.
+#       - Last entry is `assistant` without    → IDLE. Assistant finished its
+#         any `tool_use`                         turn; prompt box is waiting.
+#       - Last entry is `user` (prompt or      → ASKING. Claude Code buffers
+#         tool_result) AND not busy              the next assistant tool_use
+#                                                behind a pending permission
+#                                                prompt, so a non-busy process
+#                                                sitting on a user entry means
+#                                                it's blocked on the human.
+#
+# Net effect: BUSY is detected from process/filesystem activity; ASKING vs
+# IDLE is disambiguated from transcript shape once the process is quiet.
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FileSnap:
+    size: int
+    mtime: float
+
+
+@dataclass(frozen=True)
+class _LastJsonlEntry:
+    kind: str  # "user" or "assistant"
+    stop_reason: str | None
+    has_tool_use: bool
+
+
+@dataclass
+class _SessionProbe:
+    pid: int
+    cwd: str
+    session_id_hint: str | None = None  # sessionId as recorded in sessions/<pid>.json
+    jsonl: Path | None = None
+    cpu0: int | None = None
+    cpu1: int | None = None
+    file0: _FileSnap | None = None
+    file1: _FileSnap | None = None
+
+
+def _is_process_claude(pid: int) -> bool:
+    try:
+        comm = Path(f"/proc/{pid}/comm").read_text().strip()
+        if comm != "claude":
+            return False
+        return os.stat(f"/proc/{pid}").st_uid == os.getuid()
+    except (FileNotFoundError, PermissionError, ProcessLookupError, OSError):
+        return False
+
+
+def _get_proc_stat_fields(pid_or_tid: str | int) -> list[str] | None:
+    try:
+        raw = Path(f"/proc/{pid_or_tid}/stat").read_text()
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+        return None
+    rparen = raw.rfind(")")
+    if rparen < 0:
+        return None
+    return raw[rparen + 2 :].split()
+
+
+def _read_cpu_ticks(pid: int) -> int | None:
+    """utime+stime+cutime+cstime — total CPU ticks incl. reaped children."""
+    fields = _get_proc_stat_fields(pid)
+    if fields is None:
+        return None
+    try:
+        return int(fields[11]) + int(fields[12]) + int(fields[13]) + int(fields[14])
+    except (IndexError, ValueError):
+        return None
+
+
+def _has_process_live_child(pid: int) -> bool:
+    """True if `pid` has a child process that is actually doing work.
+
+    We only count children in states R (running) or D (uninterruptible sleep
+    / I/O) as busy-making. Children in state S (interruptible sleep) are
+    waiting on something — a user keystroke (editor opened via Ctrl-G), a
+    network poll (persistent helpers like socat under /sandbox), a pipe read
+    — and shouldn't pin the session to BUSY. Z (zombies) and T (stopped) are
+    also not work. See Layer A / signal (c) in the STRATEGY block.
+    """
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return False
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        fields = _get_proc_stat_fields(entry)
+        if fields is None:
+            continue
+        try:
+            state = fields[0]
+            ppid = int(fields[1])
+        except (IndexError, ValueError):
+            continue
+        if ppid == pid and state in ("R", "D"):
+            return True
+    return False
+
+
+def _find_active_jsonl(cwd: str, session_id_hint: str | None = None) -> Path | None:
+    """Find the live JSONL transcript for a given session.
+
+    We try two strategies in order:
+
+      1. sessionId from ~/.claude/sessions/<pid>.json
+         This is the authoritative per-PID mapping and is what lets us
+         distinguish multiple concurrent sessions sharing the same cwd
+         (they each have their own sessionId, so each resolves to its
+         own .jsonl even though they share a project_dir).
+
+      2. Newest .jsonl in the project dir (fallback)
+         Used when no hint is available, or when the hinted file is
+         missing (e.g. session-id rotation via /clear where the sessions
+         file may not yet reflect the new id). With the cwd-dedupe
+         removed this fallback is only reliable when there is a single
+         probe for the cwd; for multiple concurrent sessions the hint
+         path is what keeps them distinct.
+    """
+    encoded = cwd.replace("/", "-")
+    project_dir = PROJECTS_DIR / encoded
+    if not project_dir.is_dir():
+        return None
+
+    # Preferred: direct resolution via sessionId hint.
+    if session_id_hint:
+        candidate = project_dir / f"{session_id_hint}.jsonl"
+        if candidate.is_file():
+            return candidate
+
+    # Fallback: newest jsonl in the dir.
+    best: Path | None = None
+    best_mtime = -1.0
+    for p in project_dir.glob("*.jsonl"):
+        try:
+            mt = p.stat().st_mtime
+        except OSError:
+            continue
+        if mt > best_mtime:
+            best_mtime = mt
+            best = p
+    return best
+
+
+def _get_stat_snapshot(path: Path | None) -> _FileSnap | None:
+    if path is None:
+        return None
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return _FileSnap(size=st.st_size, mtime=st.st_mtime)
+
+
+def _get_last_jsonl_entry(path: Path | None) -> _LastJsonlEntry | None:
+    if path is None:
+        return None
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as f:
+            if size > TAIL_BYTES:
+                f.seek(-TAIL_BYTES, os.SEEK_END)
+                f.readline()  # drop possibly-partial first line
+            chunk = f.read()
+    except OSError:
+        return None
+    for raw in reversed([ln for ln in chunk.splitlines() if ln.strip()]):
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        kind = obj.get("type")
+        if kind not in ("user", "assistant"):
+            continue
+        msg = obj.get("message") or {}
+        content = msg.get("content") or []
+        has_tool_use = any(
+            isinstance(c, dict) and c.get("type") == "tool_use" for c in content
+        )
+        return _LastJsonlEntry(
+            kind=kind,
+            stop_reason=msg.get("stop_reason"),
+            has_tool_use=has_tool_use,
+        )
+    return None
+
+
+def _is_busy(p: _SessionProbe, now: float) -> bool:
+    # Layer A of the state classifier: answers "is this session working RIGHT
+    # NOW?" from externally observable signals only. Any ONE signal is enough
+    # — they cover different kinds of "busy":
+    #   (a) transcript file mutated during our sample window → writing turns.
+    #   (b) transcript file touched just before our window   → momentary lull.
+    #   (c) has a live child process                         → tool running.
+    #   (d) burned meaningful CPU during the sample window   → doing work.
+    # See the STRATEGY block above for the full rationale and thresholds.
+
+    # (a) The JSONL (size, mtime) tuple changed between the two snapshots we
+    # took SAMPLE_SECONDS apart → Claude is appending new turns/tool results.
+    if p.file0 is not None and p.file1 is not None and p.file0 != p.file1:
+        return True
+    # (b) Our sample window is short; Claude may have written just before it
+    # and paused to stream the next chunk. Treat very-recent writes as busy.
+    if p.file1 is not None and now - p.file1.mtime < RECENT_WRITE_SECONDS:
+        return True
+    # (c) A running Bash/tool subprocess is the clearest "doing work" signal
+    # even when neither the transcript nor CPU has moved in our window.
+    if _has_process_live_child(p.pid):
+        return True
+    # (d) Raw CPU-burn check. Node.js idle background (GC, timers) generates
+    # only 1–3 ticks per ~1.5s; CPU_TICK_THRESHOLD (~13% CPU) clears that
+    # noise floor so we don't false-positive on an idle event loop.
+    if (
+        p.cpu0 is not None
+        and p.cpu1 is not None
+        and p.cpu1 - p.cpu0 > CPU_TICK_THRESHOLD
+    ):
+        return True
+    return False
+
+
+def _classify(p: _SessionProbe, now: float) -> ClaudeState:
+    # Two-layer state machine:
+    #   1. If the process looks active by any external signal, it's BUSY.
+    #   2. Otherwise it's quiescent — disambiguate ASKING vs IDLE by looking
+    #      at the tail of the JSONL transcript (the shape of the last entry
+    #      tells us whether Claude is blocked on the human or truly idle).
+    if _is_busy(p, now):
+        return ClaudeState.BUSY
+
+    # Quiescent: inspect the most recent user/assistant entry in the jsonl.
+    entry = _get_last_jsonl_entry(p.jsonl)
+    if entry is None:
+        # Fresh session with no turns recorded yet → prompt box is open.
+        return ClaudeState.IDLE
+
+    if entry.kind == "assistant":
+        # Assistant spoke last. Two sub-cases:
+        if entry.has_tool_use:
+            # Assistant emitted a tool_use block and stopped — Claude Code is
+            # showing the permission menu and waiting for the user's answer.
+            return ClaudeState.ASKING
+        # Plain assistant reply with no pending tool call → turn is complete
+        # and the prompt box is waiting for the next user message.
+        return ClaudeState.IDLE
+
+    # Last entry is a user message (a typed prompt or a tool_result) and the
+    # process is not busy. Claude Code buffers the next assistant tool_use
+    # behind a pending permission prompt, so a non-busy process sitting on a
+    # user entry means it's blocked awaiting the user's answer.
+    return ClaudeState.ASKING
+
+
+def _load_session_probes() -> list[_SessionProbe]:
+    # Discovery pass for ACTIVE sessions. We walk every candidate file in
+    # ~/.claude/sessions/*.json (each live `claude` process drops one with
+    # at least {pid, cwd, sessionId}) and keep only the ones that survive
+    # validation:
+    #   - JSON parses and has both pid (int) and cwd (str);
+    #   - `_is_process_claude(pid)` confirms the PID is still alive, is
+    #     literally a `claude` binary, and is owned by the current user.
+    # We DO NOT dedupe by cwd: two `claude` processes launched from the same
+    # directory are legitimate independent sessions, each with its own pid
+    # and its own sessionId. We rely on the sessionId hint (later passed to
+    # `_find_active_jsonl`) to resolve each to its own .jsonl transcript
+    # without them colliding on the shared project_dir.
+    if not SESSIONS_DIR.is_dir():
+        return []
+    probes: list[_SessionProbe] = []
+    for entry in sorted(SESSIONS_DIR.glob("*.json")):
+        try:
+            data = json.loads(entry.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        pid = data.get("pid")
+        cwd = data.get("cwd")
+        session_id = data.get("sessionId")
+        if not (isinstance(pid, int) and isinstance(cwd, str)):
+            continue
+        if not _is_process_claude(pid):
+            continue
+        probes.append(
+            _SessionProbe(
+                pid=pid,
+                cwd=cwd,
+                session_id_hint=session_id if isinstance(session_id, str) else None,
+            )
+        )
+    return probes
+
+
+# =============================================================================
+# Public API
+# =============================================================================
+
+
+def get_sessions() -> list[ClaudeSession]:
+    """Return live Claude sessions for the current user, with state.
+
+    Blocks for ~SAMPLE_SECONDS while it samples CPU and file activity.
+    """
+    probes = _load_session_probes()
+    if not probes:
+        return []
+
+    for p in probes:
+        p.jsonl = _find_active_jsonl(p.cwd, p.session_id_hint)
+        p.cpu0 = _read_cpu_ticks(p.pid)
+        p.file0 = _get_stat_snapshot(p.jsonl)
+
+    time.sleep(SAMPLE_SECONDS)
+    now = time.time()
+
+    sessions: list[ClaudeSession] = []
+    for p in probes:
+        p.cpu1 = _read_cpu_ticks(p.pid)
+        p.file1 = _get_stat_snapshot(p.jsonl)
+        sessions.append(
+            ClaudeSession(
+                path=p.cwd,
+                name=os.path.basename(p.cwd.rstrip("/")),
+                id=p.jsonl.stem if p.jsonl is not None else "",
+                state=_classify(p, now),
+            )
+        )
+    return sessions
+
+
+def get_state_counts(
+    sessions: list[ClaudeSession] | None = None,
+) -> dict[ClaudeState, int]:
+    """Count live sessions by state. All ClaudeState keys are present."""
+    counts = {state: 0 for state in ClaudeState}
+    for s in sessions or get_sessions():
+        counts[s.state] += 1
+    return counts
+
+
+def main() -> int:
+    sessions = get_sessions()
+    state_counts = get_state_counts(sessions)
+
+    print(
+        " ".join(
+            [
+                _colorize(f" {n} {state} ", state, n > 0)
+                for state, n in state_counts.items()
+            ]
+        )
+    )
+    print()
+    for s in sessions:
+        state_colored = _colorize(f" {s.state:^6} ", s.state)
+        # print(f"{s.id[-6:]} {state_colored} {s.name}")
+        print(f"{s.id} {state_colored} {s.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/client-py/claude-mon.py
+++ b/client-py/claude-mon.py
@@ -11,23 +11,16 @@ As a module, provides:
 
 import json
 import os
-import time
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
 SESSIONS_DIR = Path.home() / ".claude" / "sessions"
 PROJECTS_DIR = Path.home() / ".claude" / "projects"
-
-SAMPLE_SECONDS = 1.5
-# CPU ticks accumulated by the claude process during the sample window that
-# we treat as "this process is actively doing work". Node.js idle background
-# activity (GC, timers) can produce 1–3 ticks in 1.5s; 20 (~13% CPU) clears it.
-CPU_TICK_THRESHOLD = 20
-# If the session's JSONL was touched within this many seconds, assume the
-# process is still mid-operation even if our brief sample caught a lull.
-RECENT_WRITE_SECONDS = 3.0
 TAIL_BYTES = 64 * 1024
+
+_CLK_TCK = os.sysconf("SC_CLK_TCK")
 
 
 # =============================================================================
@@ -56,16 +49,12 @@ class ClaudeSession:
 # ANSI colors
 # =============================================================================
 
-# --- Step 1: ANSI palette ------------------------------------------------
-# Named SGR codes. Only the basic 16-color codes are used here because `watch`
-# (and some other viewers) silently drop 256-color sequences like 48;5;208.
-
 _ANSI_RESET = "\x1b[0m"
 
 # Foregrounds
 _FG_BLACK = "\x1b[30m"
 _FG_WHITE = "\x1b[97m"
-_FG_GREY = "\x1b[90m"  # "bright black" foreground = mid-dark grey
+_FG_GREY = "\x1b[90m"
 
 # Backgrounds
 _BG_BLACK = "\x1b[40m"
@@ -73,15 +62,12 @@ _BG_RED = "\x1b[41m"
 _BG_GREEN = "\x1b[42m"
 _BG_YELLOW = "\x1b[43m"
 _BG_BLUE = "\x1b[44m"
-_BG_GREY = "\x1b[100m"  # "bright black" = mid-dark grey, standard 16-color
+_BG_GREY = "\x1b[100m"
 
 # Effects (ANSI blink applies to the foreground only)
 _FX_BLINK = "\x1b[5m"
 _FX_BOLD = "\x1b[1m"
 
-# --- Step 2: per-state style ---------------------------------------------
-# Each entry is the concatenated SGR prefix applied before the text. Tweak
-# here to re-skin a state — e.g. `ClaudeState.AWAITING_PROMPT: _FG_WHITE + _BG_RED`.
 _STATE_STYLE: dict[ClaudeState, str] = {
     ClaudeState.BUSY: _FG_BLACK + _BG_RED,
     ClaudeState.ASKING: _FG_BLACK + _BG_YELLOW + _FX_BLINK,
@@ -93,8 +79,7 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
     """Wrap `text` in the ANSI style defined for `state`."""
     if not doit:
         return f"{_BG_BLACK}{_FG_GREY}{text}{_ANSI_RESET}"
-    else:
-        return f"{_STATE_STYLE[state]}{text}{_ANSI_RESET}"
+    return f"{_STATE_STYLE[state]}{text}{_ANSI_RESET}"
 
 
 # =============================================================================
@@ -104,113 +89,66 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 # -----------------------------------------------------------------------------
 # STRATEGY — how we find ACTIVE sessions
 # -----------------------------------------------------------------------------
-# Claude Code does not expose a public "list my sessions" API, so we reverse
-# the problem by combining two filesystem sources plus /proc:
+# Two filesystem sources + /proc:
 #
 #   1. ~/.claude/sessions/<pid>.json
-#        Each running `claude` process drops a small JSON file here recording
-#        { "pid": ..., "cwd": ..., "sessionId": ..., ... }. This is our
-#        ENUMERATION source: it tells us which PIDs *claim* to be Claude Code
-#        sessions, the working directory each was launched from, and the
-#        session id to use as a direct pointer into (3). See
-#        `_load_session_probes`.
+#        Each live `claude` process drops { pid, cwd, sessionId, ... } here.
+#        ENUMERATION source. See `_load_session_probes`.
 #
 #   2. /proc/<pid>  (Linux only)
-#        The sessions file can be stale (process died without cleanup, PID
-#        was recycled, another user's PID collides). So for every candidate
-#        we VERIFY via /proc that:
-#           - the PID still exists,
-#           - its comm is literally "claude",
-#           - it is owned by the current UID.
-#        That is `_is_process_claude`. Only survivors count as "active".
+#        Verifies the candidate PID is still alive, has comm == "claude",
+#        and is owned by the current UID. See `_is_process_claude`.
 #
 #   3. ~/.claude/projects/<encoded-cwd>/*.jsonl
-#        Claude Code writes a JSONL transcript per session here, where
-#        <encoded-cwd> is the absolute cwd with "/" replaced by "-". To map
-#        a PID to its OWN transcript (crucial when two sessions share a cwd
-#        and therefore share this project_dir) we use the sessionId from
-#        sessions/<pid>.json: the live jsonl is <project_dir>/<sessionId>.jsonl.
-#        If the hint is missing or its file doesn't exist (e.g. /clear just
-#        rotated the id and the sessions file hasn't caught up yet) we fall
-#        back to the newest .jsonl in the project_dir. See `_find_active_jsonl`.
-#
-# We do NOT dedupe by cwd: concurrent sessions in the same directory are
-# legitimate and each has its own pid + sessionId, which the hint-based
-# resolver keeps separate.
+#        The transcript. Resolved per-probe by `_find_active_jsonl`:
+#          - solo probe for the cwd → newest jsonl (immune to /clear id
+#            rotation that leaves sessions/<pid>.json stale);
+#          - multiple concurrent probes for the same cwd → each uses its
+#            own sessionId to pick its own jsonl (only way to keep them
+#            distinct when they share a project_dir).
 #
 # -----------------------------------------------------------------------------
-# STRATEGY — how we classify each active session into BUSY / ASKING / IDLE
+# STRATEGY — how we classify BUSY / ASKING / IDLE
 # -----------------------------------------------------------------------------
-# We don't have an IPC hook into the running `claude` process, so we infer
-# state from externally-observable signals. The classifier runs in two layers:
+# Single authoritative observable: the tail of the JSONL transcript.
 #
-#   Layer A — "is it BUSY right now?"  (see `_is_busy`)
-#     We take two snapshots SAMPLE_SECONDS apart and declare BUSY if ANY of:
-#       (a) The active JSONL's (size, mtime) changed between the two samples
-#           → the process is actively appending turns / tool results.
-#       (b) The JSONL's mtime is within RECENT_WRITE_SECONDS of "now"
-#           → it wrote very recently; our 1.5s window may have caught a lull
-#             between a tool result and the next assistant turn.
-#       (c) The process has at least one child in /proc whose state is R
-#           (running) or D (uninterruptible sleep / I/O)
-#           → a Bash/tool subprocess is actively burning CPU or doing I/O.
-#           We deliberately ignore children in state S: those are sleeping
-#           on a pipe/poll/read (Ctrl-G editor, persistent helpers like the
-#           socat processes spawned by /sandbox, etc.) and don't represent
-#           work Claude is waiting on.
-#       (d) CPU ticks accumulated by the process during the sample window
-#           exceed CPU_TICK_THRESHOLD
-#           → Node.js idle bookkeeping (GC, timers) produces only a handful
-#             of ticks; anything well above that means real work (token
-#             streaming, JSON parsing, tool dispatch, ...).
-#     Any single signal is enough; they are complementary so we can catch
-#     both "writing to disk" work and "waiting on a child tool" work.
+#   last entry                                | state
+#   ------------------------------------------|--------
+#   none (fresh session)                      | IDLE
+#   `user` (prompt submitted or tool_result)  | BUSY
+#   `assistant` with `tool_use` content       | ASKING*
+#   `assistant` without `tool_use`            | IDLE
 #
-#   Layer B — "if not busy, is it ASKING or IDLE?"  (see `_classify`)
-#     When idle-looking, we tail the active JSONL and inspect the LAST
-#     user/assistant entry:
-#       - No parseable entry yet               → IDLE (fresh/blank session).
-#       - Last entry is `assistant` with a     → ASKING. Claude has emitted
-#         `tool_use` content block               a tool call and is waiting
-#                                                for the user to approve it
-#                                                via the permission menu.
-#       - Last entry is `assistant` without    → IDLE. Assistant finished its
-#         any `tool_use`                         turn; prompt box is waiting.
-#       - Last entry is `user` (prompt or      → ASKING. Claude Code buffers
-#         tool_result) AND not busy              the next assistant tool_use
-#                                                behind a pending permission
-#                                                prompt, so a non-busy process
-#                                                sitting on a user entry means
-#                                                it's blocked on the human.
+#   * Refinement: "ASKING" is ambiguous between (a) permission modal waiting
+#     for the user, and (b) tool was approved and is now executing. We
+#     disambiguate by checking the start time of claude's children:
+#       - any child spawned AFTER the tool_use entry's timestamp
+#         → tool is running → BUSY;
+#       - no such child → ASKING stays.
+#     This uses /proc/<cpid>/stat field 22 (`starttime` in clock ticks
+#     since boot) plus /proc/stat `btime` (boot epoch). Persistent helpers
+#     (socat from /sandbox, editors from Ctrl-G) predate the tool_use and
+#     are correctly ignored.
 #
-# Net effect: BUSY is detected from process/filesystem activity; ASKING vs
-# IDLE is disambiguated from transcript shape once the process is quiet.
+# We do not sample over time — no CPU ticks, no mtime deltas, no grace
+# windows. Transitions appear with whatever latency the JSONL and /proc
+# themselves exhibit, which is the minimum achievable by a passive monitor.
 # -----------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
-class _FileSnap:
-    size: int
-    mtime: float
-
-
-@dataclass(frozen=True)
-class _LastJsonlEntry:
+class _LastEntry:
     kind: str  # "user" or "assistant"
-    stop_reason: str | None
     has_tool_use: bool
+    timestamp: float | None  # epoch seconds, None if missing/unparseable
 
 
 @dataclass
 class _SessionProbe:
     pid: int
     cwd: str
-    session_id_hint: str | None = None  # sessionId as recorded in sessions/<pid>.json
+    session_id_hint: str | None = None
     jsonl: Path | None = None
-    cpu0: int | None = None
-    cpu1: int | None = None
-    file0: _FileSnap | None = None
-    file1: _FileSnap | None = None
 
 
 def _is_process_claude(pid: int) -> bool:
@@ -234,31 +172,27 @@ def _get_proc_stat_fields(pid_or_tid: str | int) -> list[str] | None:
     return raw[rparen + 2 :].split()
 
 
-def _read_cpu_ticks(pid: int) -> int | None:
-    """utime+stime+cutime+cstime — total CPU ticks incl. reaped children."""
-    fields = _get_proc_stat_fields(pid)
-    if fields is None:
-        return None
+def _boot_time() -> float:
+    """System boot as epoch seconds, from /proc/stat `btime`."""
     try:
-        return int(fields[11]) + int(fields[12]) + int(fields[13]) + int(fields[14])
-    except (IndexError, ValueError):
-        return None
+        for line in Path("/proc/stat").read_text().splitlines():
+            if line.startswith("btime "):
+                return float(line.split()[1])
+    except OSError:
+        pass
+    return 0.0
 
 
-def _has_process_live_child(pid: int) -> bool:
-    """True if `pid` has a child process that is actually doing work.
-
-    We only count children in states R (running) or D (uninterruptible sleep
-    / I/O) as busy-making. Children in state S (interruptible sleep) are
-    waiting on something — a user keystroke (editor opened via Ctrl-G), a
-    network poll (persistent helpers like socat under /sandbox), a pipe read
-    — and shouldn't pin the session to BUSY. Z (zombies) and T (stopped) are
-    also not work. See Layer A / signal (c) in the STRATEGY block.
-    """
+def _child_start_times(pid: int) -> list[float]:
+    """Epoch start times of non-zombie direct children of `pid`."""
+    btime = _boot_time()
+    if btime == 0.0:
+        return []
     try:
         entries = os.listdir("/proc")
     except OSError:
-        return False
+        return []
+    starts: list[float] = []
     for entry in entries:
         if not entry.isdigit():
             continue
@@ -268,44 +202,17 @@ def _has_process_live_child(pid: int) -> bool:
         try:
             state = fields[0]
             ppid = int(fields[1])
+            # fields[19] = 22nd stat field (starttime in clock ticks since boot)
+            starttime_ticks = int(fields[19])
         except (IndexError, ValueError):
             continue
-        if ppid == pid and state in ("R", "D"):
-            return True
-    return False
+        if ppid != pid or state == "Z":
+            continue
+        starts.append(btime + starttime_ticks / _CLK_TCK)
+    return starts
 
 
-def _find_active_jsonl(cwd: str, session_id_hint: str | None = None) -> Path | None:
-    """Find the live JSONL transcript for a given session.
-
-    We try two strategies in order:
-
-      1. sessionId from ~/.claude/sessions/<pid>.json
-         This is the authoritative per-PID mapping and is what lets us
-         distinguish multiple concurrent sessions sharing the same cwd
-         (they each have their own sessionId, so each resolves to its
-         own .jsonl even though they share a project_dir).
-
-      2. Newest .jsonl in the project dir (fallback)
-         Used when no hint is available, or when the hinted file is
-         missing (e.g. session-id rotation via /clear where the sessions
-         file may not yet reflect the new id). With the cwd-dedupe
-         removed this fallback is only reliable when there is a single
-         probe for the cwd; for multiple concurrent sessions the hint
-         path is what keeps them distinct.
-    """
-    encoded = cwd.replace("/", "-")
-    project_dir = PROJECTS_DIR / encoded
-    if not project_dir.is_dir():
-        return None
-
-    # Preferred: direct resolution via sessionId hint.
-    if session_id_hint:
-        candidate = project_dir / f"{session_id_hint}.jsonl"
-        if candidate.is_file():
-            return candidate
-
-    # Fallback: newest jsonl in the dir.
+def _newest_jsonl(project_dir: Path) -> Path | None:
     best: Path | None = None
     best_mtime = -1.0
     for p in project_dir.glob("*.jsonl"):
@@ -319,17 +226,60 @@ def _find_active_jsonl(cwd: str, session_id_hint: str | None = None) -> Path | N
     return best
 
 
-def _get_stat_snapshot(path: Path | None) -> _FileSnap | None:
-    if path is None:
+def _find_active_jsonl(cwd: str, session_id_hint: str | None, solo: bool) -> Path | None:
+    """Resolve a probe's live JSONL transcript.
+
+    - solo probe for the cwd → newest jsonl in the project_dir. This is
+      robust against /clear-driven sessionId rotation where
+      sessions/<pid>.json may not reflect the new id.
+    - multiple probes share the cwd → each probe's sessionId hint is the
+      only way to distinguish them. We do NOT fall back to newest, which
+      would cause all same-cwd probes to collide on the same file.
+    """
+    encoded = cwd.replace("/", "-")
+    project_dir = PROJECTS_DIR / encoded
+    if not project_dir.is_dir():
         return None
+    if solo:
+        return _newest_jsonl(project_dir)
+    if session_id_hint:
+        candidate = project_dir / f"{session_id_hint}.jsonl"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _parse_timestamp(s: str | None) -> float | None:
+    if not isinstance(s, str) or not s:
+        return None
+    # Claude writes ISO 8601 like "2026-04-19T21:46:27.752Z".
     try:
-        st = path.stat()
-    except OSError:
+        normalized = s.replace("Z", "+00:00") if s.endswith("Z") else s
+        return datetime.fromisoformat(normalized).timestamp()
+    except ValueError:
         return None
-    return _FileSnap(size=st.st_size, mtime=st.st_mtime)
 
 
-def _get_last_jsonl_entry(path: Path | None) -> _LastJsonlEntry | None:
+# Slash-command audit markers: Claude Code writes these as type="user"
+# entries, but they are *not* user prompts — they are internal records of
+# commands like /clear, /compact, etc. Including them in the tail scan
+# would misclassify a freshly /clear'd session as BUSY.
+_INTERNAL_USER_PREFIXES = (
+    "<command-name>",
+    "<local-command-caveat>",
+    "<local-command-stdout>",
+    "<local-command-stderr>",
+)
+
+
+def _is_internal_user_content(content) -> bool:
+    if not isinstance(content, str):
+        return False
+    stripped = content.lstrip()
+    return any(stripped.startswith(p) for p in _INTERNAL_USER_PREFIXES)
+
+
+def _get_last_entry(path: Path | None) -> _LastEntry | None:
     if path is None:
         return None
     try:
@@ -351,96 +301,36 @@ def _get_last_jsonl_entry(path: Path | None) -> _LastJsonlEntry | None:
             continue
         msg = obj.get("message") or {}
         content = msg.get("content") or []
+        if kind == "user" and _is_internal_user_content(content):
+            continue
         has_tool_use = any(
             isinstance(c, dict) and c.get("type") == "tool_use" for c in content
         )
-        return _LastJsonlEntry(
+        return _LastEntry(
             kind=kind,
-            stop_reason=msg.get("stop_reason"),
             has_tool_use=has_tool_use,
+            timestamp=_parse_timestamp(obj.get("timestamp")),
         )
     return None
 
 
-def _is_busy(p: _SessionProbe, now: float) -> bool:
-    # Layer A of the state classifier: answers "is this session working RIGHT
-    # NOW?" from externally observable signals only. Any ONE signal is enough
-    # — they cover different kinds of "busy":
-    #   (a) transcript file mutated during our sample window → writing turns.
-    #   (b) transcript file touched just before our window   → momentary lull.
-    #   (c) has a live child process                         → tool running.
-    #   (d) burned meaningful CPU during the sample window   → doing work.
-    # See the STRATEGY block above for the full rationale and thresholds.
-
-    # (a) The JSONL (size, mtime) tuple changed between the two snapshots we
-    # took SAMPLE_SECONDS apart → Claude is appending new turns/tool results.
-    if p.file0 is not None and p.file1 is not None and p.file0 != p.file1:
-        return True
-    # (b) Our sample window is short; Claude may have written just before it
-    # and paused to stream the next chunk. Treat very-recent writes as busy.
-    if p.file1 is not None and now - p.file1.mtime < RECENT_WRITE_SECONDS:
-        return True
-    # (c) A running Bash/tool subprocess is the clearest "doing work" signal
-    # even when neither the transcript nor CPU has moved in our window.
-    if _has_process_live_child(p.pid):
-        return True
-    # (d) Raw CPU-burn check. Node.js idle background (GC, timers) generates
-    # only 1–3 ticks per ~1.5s; CPU_TICK_THRESHOLD (~13% CPU) clears that
-    # noise floor so we don't false-positive on an idle event loop.
-    if (
-        p.cpu0 is not None
-        and p.cpu1 is not None
-        and p.cpu1 - p.cpu0 > CPU_TICK_THRESHOLD
-    ):
-        return True
-    return False
-
-
-def _classify(p: _SessionProbe, now: float) -> ClaudeState:
-    # Two-layer state machine:
-    #   1. If the process looks active by any external signal, it's BUSY.
-    #   2. Otherwise it's quiescent — disambiguate ASKING vs IDLE by looking
-    #      at the tail of the JSONL transcript (the shape of the last entry
-    #      tells us whether Claude is blocked on the human or truly idle).
-    if _is_busy(p, now):
-        return ClaudeState.BUSY
-
-    # Quiescent: inspect the most recent user/assistant entry in the jsonl.
-    entry = _get_last_jsonl_entry(p.jsonl)
+def _classify(pid: int, entry: _LastEntry | None) -> ClaudeState:
     if entry is None:
-        # Fresh session with no turns recorded yet → prompt box is open.
         return ClaudeState.IDLE
-
-    if entry.kind == "assistant":
-        # Assistant spoke last. Two sub-cases:
-        if entry.has_tool_use:
-            # Assistant emitted a tool_use block and stopped — Claude Code is
-            # showing the permission menu and waiting for the user's answer.
-            return ClaudeState.ASKING
-        # Plain assistant reply with no pending tool call → turn is complete
-        # and the prompt box is waiting for the next user message.
+    if entry.kind == "user":
+        return ClaudeState.BUSY
+    # entry.kind == "assistant"
+    if not entry.has_tool_use:
         return ClaudeState.IDLE
-
-    # Last entry is a user message (a typed prompt or a tool_result) and the
-    # process is not busy. Claude Code buffers the next assistant tool_use
-    # behind a pending permission prompt, so a non-busy process sitting on a
-    # user entry means it's blocked awaiting the user's answer.
+    # tool_use present: disambiguate "permission pending" vs "tool running".
+    if entry.timestamp is not None:
+        for start in _child_start_times(pid):
+            if start > entry.timestamp:
+                return ClaudeState.BUSY
     return ClaudeState.ASKING
 
 
 def _load_session_probes() -> list[_SessionProbe]:
-    # Discovery pass for ACTIVE sessions. We walk every candidate file in
-    # ~/.claude/sessions/*.json (each live `claude` process drops one with
-    # at least {pid, cwd, sessionId}) and keep only the ones that survive
-    # validation:
-    #   - JSON parses and has both pid (int) and cwd (str);
-    #   - `_is_process_claude(pid)` confirms the PID is still alive, is
-    #     literally a `claude` binary, and is owned by the current user.
-    # We DO NOT dedupe by cwd: two `claude` processes launched from the same
-    # directory are legitimate independent sessions, each with its own pid
-    # and its own sessionId. We rely on the sessionId hint (later passed to
-    # `_find_active_jsonl`) to resolve each to its own .jsonl transcript
-    # without them colliding on the shared project_dir.
     if not SESSIONS_DIR.is_dir():
         return []
     probes: list[_SessionProbe] = []
@@ -474,30 +364,27 @@ def _load_session_probes() -> list[_SessionProbe]:
 def get_sessions() -> list[ClaudeSession]:
     """Return live Claude sessions for the current user, with state.
 
-    Blocks for ~SAMPLE_SECONDS while it samples CPU and file activity.
+    Non-blocking: single /proc + filesystem pass, no sampling window.
     """
     probes = _load_session_probes()
     if not probes:
         return []
 
+    cwd_counts: dict[str, int] = {}
     for p in probes:
-        p.jsonl = _find_active_jsonl(p.cwd, p.session_id_hint)
-        p.cpu0 = _read_cpu_ticks(p.pid)
-        p.file0 = _get_stat_snapshot(p.jsonl)
-
-    time.sleep(SAMPLE_SECONDS)
-    now = time.time()
+        cwd_counts[p.cwd] = cwd_counts.get(p.cwd, 0) + 1
 
     sessions: list[ClaudeSession] = []
     for p in probes:
-        p.cpu1 = _read_cpu_ticks(p.pid)
-        p.file1 = _get_stat_snapshot(p.jsonl)
+        solo = cwd_counts[p.cwd] == 1
+        p.jsonl = _find_active_jsonl(p.cwd, p.session_id_hint, solo)
+        entry = _get_last_entry(p.jsonl)
         sessions.append(
             ClaudeSession(
                 path=p.cwd,
                 name=os.path.basename(p.cwd.rstrip("/")),
                 id=p.jsonl.stem if p.jsonl is not None else "",
-                state=_classify(p, now),
+                state=_classify(p.pid, entry),
             )
         )
     return sessions
@@ -528,8 +415,8 @@ def main() -> int:
     print()
     for s in sessions:
         state_colored = _colorize(f" {s.state:^6} ", s.state)
-        # print(f"{s.id[-6:]} {state_colored} {s.name}")
-        print(f"{s.id} {state_colored} {s.name}")
+        print(f"{s.id[-6:]} {state_colored} {s.name}")
+        # print(f"{s.id} {state_colored} {s.name}")
     return 0
 
 

--- a/client-py/claude-mon.py
+++ b/client-py/claude-mon.py
@@ -139,6 +139,159 @@ def _colorize(text: str, state: ClaudeState, doit: bool = True) -> str:
 # We do not sample over time — no CPU ticks, no mtime deltas, no grace
 # windows. Transitions appear with whatever latency the JSONL and /proc
 # themselves exhibit, which is the minimum achievable by a passive monitor.
+#
+# -----------------------------------------------------------------------------
+# ASSUMPTIONS — undocumented Claude Code internals this classifier depends on
+# -----------------------------------------------------------------------------
+# Claude Code does not publish a stable spec for any of the artifacts below.
+# Everything here was reverse-engineered from live installations (v2.1.114 at
+# time of writing — see the `version` field on any jsonl entry). Each item
+# below is an ASSUMPTION with a pointer to the code site that depends on it
+# and a note on how to diagnose and fix breakage if the internal changes.
+#
+# If sessions stop classifying, start by running:
+#     jq -c 'del(.message, .snapshot, .content)' <~/.claude/projects/.../*.jsonl
+# to get a fieldset-only view of the current on-disk schema, and compare
+# against the assumptions below. Most drifts are one renamed field away.
+#
+# Summary:
+#   A. Filesystem layout — sessions/<pid>.json, cwd-to-project-dir encoding,
+#      /clear rotation behavior.
+#   B. JSONL top-level entry types — which type values we act on vs. skip
+#      (enumerated from scanning every project transcript on the system); ISO
+#      8601 timestamp format.
+#   C. message.content shape — the user=string|list, assistant=list-of-blocks
+#      distinction and how breakage would manifest.
+#   D. Slash-command audit records — the four <…> string prefixes we filter;
+#      how to recognize a new one.
+#   E. Turn-end system subtypes — the two that force IDLE (turn_duration,
+#      away_summary) vs. the five observed non-turn-end subtypes that must not be
+#      added (local_command, api_error, compact_boundary, scheduled_task_fire,
+#      informational).
+#   F. Tool execution model — "direct child spawned after tool_use timestamp"
+#      and what breaks if Claude switches to an orchestrator model.
+#   G. Process identity — the 7-byte comm "claude" check.
+#   H. /proc schema — field offsets and the Linux constants we rely on.
+#
+# Details:
+#
+# A. Filesystem layout
+#    A1. Per-pid session file: ~/.claude/sessions/<pid>.json
+#        Used in: _load_session_probes, SESSIONS_DIR.
+#        Verified shape (v2.1.114):
+#            {"pid":int, "sessionId":uuid-str, "cwd":abspath-str,
+#             "startedAt":ms-int, "version":str, "kind":"interactive",
+#             "entrypoint":"cli"}
+#        If the filename pattern or the {pid, cwd, sessionId} triplet moves,
+#        rewrite _load_session_probes. The only hard requirement is some way
+#        to map live pid → current sessionId → transcript path.
+#
+#    A2. Transcript path: ~/.claude/projects/<cwd-with-"/"-as-"-">/<sid>.jsonl
+#        Used in: _find_active_jsonl, PROJECTS_DIR, `encoded = cwd.replace("/", "-")`.
+#        If the encoding changes (e.g. includes a hash, or handles "-" in
+#        paths differently), update the `encoded = ...` line. Symptom: probes
+#        resolve to None for cwds that contain unusual characters.
+#
+#    A3. sessionId rotation behavior: `/clear` allocates a new sessionId and
+#        starts a fresh jsonl, but does NOT rewrite ~/.claude/sessions/<pid>.json.
+#        The hint there therefore goes stale until some unknown next write.
+#        Used in: _find_active_jsonl's solo-branch fallback to newest-jsonl.
+#        If a future version starts rewriting the sessions file atomically
+#        on /clear, the newest-jsonl fallback becomes redundant but harmless.
+#        If it starts writing a per-session tombstone file or similar, we
+#        could drop the solo/multi branching altogether.
+#
+# B. JSONL top-level entry types
+#    B1. Entry types we ACT on: "user", "assistant", "system".
+#        Entry types we IGNORE (skipped by _get_last_entry's outer filter):
+#        "attachment", "permission-mode", "file-history-snapshot",
+#        "last-prompt", "summary".
+#        Used in: _get_last_entry's `if kind not in ("user","assistant"): continue`.
+#        If a new type appears that represents "user is being asked for
+#        something" or "turn ended", add it to the relevant clause.
+#
+#    B2. Every entry carries "timestamp" as ISO 8601 with "Z" suffix,
+#        e.g. "2026-04-19T21:46:27.752Z".
+#        Used in: _parse_timestamp.
+#        Python 3.11+ fromisoformat accepts "+00:00" but not "Z" before 3.11,
+#        so we normalize. If the format changes to epoch-ms or RFC 2822,
+#        update _parse_timestamp.
+#
+# C. JSONL message.content shape
+#    C1. "user".message.content may be:
+#          - a STRING (plain text prompt OR a slash-command audit record),
+#          - a LIST of content blocks (tool_result with {type:"tool_result", ...}).
+#        "assistant".message.content is always a LIST of blocks
+#        with block.type in {"text","tool_use","thinking","redacted_thinking"}.
+#        Used in: _get_last_entry's has_tool_use scan, _is_internal_user_content.
+#        If assistant.content ever becomes a bare string again (Anthropic API
+#        style), the `any(isinstance(c,dict)...)` check silently returns False
+#        and every tool_use becomes invisible → everything classifies as IDLE
+#        or BUSY (never ASKING). Symptom: permission menus never show ASKING.
+#
+# D. Slash-command audit records (internal user entries to skip)
+#    D1. When the user runs a slash command, Claude Code appends user-type
+#        entries whose content is a STRING starting with one of:
+#            <command-name>…            (the command invocation itself)
+#            <local-command-caveat>…    (boilerplate attached to some commands)
+#            <local-command-stdout>…    (stdout of locally-run commands)
+#            <local-command-stderr>…    (stderr of same)
+#        These are NOT user prompts; treating them as one misclassifies a
+#        freshly /clear'd session as BUSY.
+#        Used in: _INTERNAL_USER_PREFIXES, _is_internal_user_content.
+#        If new audit tags appear (likely for new slash-commands), add the
+#        prefix to _INTERNAL_USER_PREFIXES. Symptom: a session sits at BUSY
+#        indefinitely after some specific slash-command usage — dump the
+#        tail and look for a `<something>…</something>` user entry that
+#        we're not skipping.
+#
+# E. Turn-end system subtypes
+#    E1. Claude Code appends one of these system entries when a turn has
+#        definitively wrapped up and the process is awaiting the next prompt:
+#            {type:"system", subtype:"turn_duration", durationMs, messageCount, …}
+#            {type:"system", subtype:"away_summary", content:<summary>, …}
+#        Used in: _TURN_END_SUBTYPES, _LastEntry.turn_ended, _classify.
+#        Without this override, a tool_result user entry appearing as the tail
+#        would keep a completed turn showing as BUSY. Other observed system
+#        subtypes (NOT turn-ending, must not be added): "local_command",
+#        "api_error", "compact_boundary", "scheduled_task_fire",
+#        "informational". If a new turn-end subtype appears, add to the
+#        frozenset. Symptom: idle sessions permanently stuck on BUSY
+#        immediately after a tool call turn.
+#
+# F. Tool execution model
+#    F1. When Claude runs a tool that requires a subprocess (Bash, and
+#        anything delegating to one), it spawns a DIRECT child of the claude
+#        PID, and that child's start time is AFTER the `assistant` entry
+#        containing the tool_use block was written.
+#        Used in: _child_start_times + _classify's refinement loop.
+#        In-process tools (Read, Edit, Grep, Glob, Write, TodoWrite, etc.)
+#        do NOT spawn a child; we can't distinguish "permission pending"
+#        from "in-process tool executing" for those — they briefly show as
+#        ASKING during execution. Accepted limitation.
+#        If Claude Code switches Bash to an in-process library, or starts
+#        using an orchestrator process (so claude's direct child becomes a
+#        persistent helper instead of the tool itself), the refinement
+#        breaks. Symptom: `Bash sleep 30` shows as ASKING throughout, OR
+#        every session pins to BUSY (if the orchestrator is long-lived).
+#        Fix: walk the process tree recursively, or match the new helper
+#        by comm and look one level deeper.
+#
+# G. Process identity
+#    G1. Claude Code's `/proc/<pid>/comm` is literally the 7-byte string
+#        "claude". If the binary is ever renamed (e.g. to "claude-code"),
+#        _is_process_claude returns False for every PID → no sessions
+#        detected. Symptom: empty output. Fix: update the comm check.
+#
+# H. /proc schema (Linux, stable across kernels but noted for completeness)
+#    H1. /proc/<pid>/stat field layout: 3rd field onwards = state, ppid,
+#        pgrp, …, 22nd field = starttime (clock ticks since boot).
+#        After stripping "pid (comm) " the 22nd becomes fields[19].
+#        Used in: _child_start_times, _get_proc_stat_fields.
+#    H2. /proc/stat contains a "btime <epoch>" line giving boot time.
+#        Used in: _boot_time.
+#    H3. SC_CLK_TCK gives ticks-per-second (almost always 100).
+#        Used in: _CLK_TCK module constant.
 # -----------------------------------------------------------------------------
 
 

--- a/server-esp32s3-rtft/command.cpp
+++ b/server-esp32s3-rtft/command.cpp
@@ -510,6 +510,12 @@ const char *interpret(char *input, const Config &config) {
         case hash("setFont"): {  //
       */
 
+    case hash("hardcopy"): {  // hardcopy
+      transaction.commit();
+      tft.begin();
+      return null;
+    }
+
     default:
       break;
   }


### PR DESCRIPTION
## Summary

Evolves `client-py/claude-mon.py` from a first-pass classifier that stacked proxy heuristics (CPU ticks, mtime deltas, grace windows) into a tight JSONL-tail-driven classifier that's ~30× faster and handles several cases the original got wrong. Also adds per-session token/throughput reporting.

**Classifier changes (commit by commit):**
- `dcb306a` — honor `system/turn_duration` / `away_summary` turn-end markers; fall back to `sessions/<pid>.json` sessionId hint so id is populated before the first prompt.
- `4cb99a1` — add ASSUMPTIONS block documenting every reverse-engineered Claude Code internal the classifier depends on (sessions schema, transcript path encoding, entry types, message.content shape, slash-command audit prefixes, turn-end subtypes, tool-execution model, /proc schema), each with a pointer to the code site and a diagnostic symptom for drift.
- `ebd3284` — fix two ASKING misclassifications: (1) Bash/subprocess tools — child is spawned ~100–200 ms *before* the tool_use jsonl write, so compare child.start to the *previous* turn boundary, not the current entry; (2) in-process tools (Read/Edit/Grep/…) leave no /proc signal, so correlate tool_use_id ↔ tool_result from the transcript as a fast path.
- `8dc74f7` — cumulative per-session token usage (fresh / cache-create / cache-read, summed as total input since using `input_tokens` alone underreports ~100× on cached sessions) + active compute time from `system/turn_duration.durationMs` → throughput t/s.
- `ae3997a` — detect live in-process Agent subagents via `<project_dir>/<sid>/subagents/agent-*.jsonl` sidechain transcripts. Without this, long subagent runs pinned at ASKING because the parent tool_result in parallel-tool batches is gated on the slowest sibling.

Also: `4cb99a1` includes a small firmware addition (`hardcopy` command in `server-esp32s3-rtft/command.cpp`).

## Test plan

- [ ] Run `python3 client-py/claude-mon.py` with an idle session → IDLE
- [ ] Same, while a Bash tool is executing → BUSY
- [ ] Same, while an in-process tool (Read/Edit/Grep) is executing → BUSY (not ASKING)
- [ ] Same, while an Agent subagent is running → BUSY (not ASKING)
- [ ] Awaiting permission modal → ASKING
- [ ] After `/clear`, id is still shown
- [ ] Token/throughput metrics print alongside state
- [ ] `get_sessions()` latency stays under ~50 ms on a machine with several active sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)