### PR TITLE
[impl] Adopt ruff (format + lint), drop mypy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,7 @@
+SHELL := /bin/bash
 
-MYPY_OPTS :=
-MYPY_OPTS += --explicit-package-bases
-MYPY_OPTS += --follow-imports=silent
-MYPY_OPTS += --ignore-missing-imports
-MYPY_OPTS += --namespace-packages
-MYPY_OPTS += --no-strict-optional
-MYPY_OPTS += --pretty
-MYPY_OPTS += --strict
-MYPY_OPTS += --strict-equality
-MYPY_OPTS += --warn-redundant-casts
-MYPY_OPTS += --warn-return-any
-MYPY_OPTS += --warn-unreachable
+# Interim ruff-based quality targets (mypy dropped, #9).
+# The full uv-based two-level Makefile lands with task G (#TODO item 5).
 
 .PHONY: *
 
@@ -24,8 +15,12 @@ help:	## print this help
 require: ## install dependencies (Python)
 	pip install -r client-py/requirements.txt
 
-lint: ## lint (Python)
-	mypy $(MYPY_OPTS) $$(find -P -name "*.py")
+lint: ## lint + format-check (ruff, read-only)
+	cd client-py && uv tool run ruff check . && uv tool run ruff format --check .
 
-clean: ## remove tmp files
-	rm -rf .mypy_cache
+format: ## format + lint autofix (ruff, modifies code)
+	cd client-py && uv tool run ruff format . && uv tool run ruff check --fix .
+
+clean: ## remove caches
+	rm -rf .ruff_cache .pytest_cache .mypy_cache
+	find . -type d -name __pycache__ -prune -exec rm -rf {} +

--- a/client-py/app/__init__.py
+++ b/client-py/app/__init__.py
@@ -1,6 +1,6 @@
-import re
 import datetime
 import random
+import re
 import time
 from abc import abstractmethod
 from typing import Callable

--- a/client-py/app/asteriods.py
+++ b/client-py/app/asteriods.py
@@ -531,7 +531,7 @@ class Detect:
         dx = (a.x - x) ** 2
         dy = (a.y - y) ** 2
         r2 = (dx + dy) * factor
-        return r2 < a.r ** 2
+        return r2 < a.r**2
 
 
 class Autoplay:
@@ -600,7 +600,7 @@ class Asteriods(App):
 
     def menu(self) -> int:
         self.show_header('', 'C:next B:play A:demo')
-        self.gfx.print(f'\\n')
+        self.gfx.print('\\n')
         self.gfx.print(f'{self.name.upper()} keys:\\n')
         self.gfx.print(f' {KEY_FIRE}   fire\\n')
         self.gfx.print(f' {KEY_CCW}   cntr-clockwise\\n')

--- a/client-py/app/bumps.py
+++ b/client-py/app/bumps.py
@@ -1,4 +1,3 @@
-import config
 from app import App, Sprite, TimeEscaper
 from lib.board import Board
 

--- a/client-py/app/claude_mon.py
+++ b/client-py/app/claude_mon.py
@@ -17,19 +17,20 @@ board using the `lib.gfx` local library for rendering text and graphics.
 
 from __future__ import annotations
 
-from math import cos, sin
 import random
 import time
 from dataclasses import dataclass
 from enum import Enum
+from math import cos
 
-from app import App, TimeEscaper
 from claude_busy_monitor import (
     ClaudeSession,
     ClaudeState,
     get_sessions,
     get_state_counts,
 )
+
+from app import App, TimeEscaper
 from lib.board import Board
 from lib.gfx import Gfx
 
@@ -261,7 +262,6 @@ class ClaudeChar:
 
 
 class Clauding:
-
     def __init__(self, width):
         self.width = width
         self.claude_chars = ClaudeChar()

--- a/client-py/app/collisions.py
+++ b/client-py/app/collisions.py
@@ -9,12 +9,10 @@ Quite crowded, no gravity, elastic bumps.
 from __future__ import annotations
 
 import random
-from dataclasses import dataclass
 from itertools import combinations
-from typing import Any, Callable
+from typing import Callable
 
 import numpy as np
-from numpy.typing import NDArray
 
 import config
 from app import App, TimeEscaper
@@ -49,7 +47,7 @@ class Particle:
         self.r = np.array((x, y))
         self.v = np.array((vx, vy))
         self.radius = radius
-        self.mass = self.radius ** 2
+        self.mass = self.radius**2
         self.rgb = rgb
         self.rgb_hit = rgb_hit
         self.is_hit_by_wall: bool = False

--- a/client-py/app/collisions3.py
+++ b/client-py/app/collisions3.py
@@ -4,11 +4,10 @@ Quite crowded, no gravity, bubble grow with time and pop on mutual collision.
 """
 
 from app.collisions import (
-    CollisionsElastic,
-    Simulation,
     TIME_SUBQUANTAS,
-    Color,
+    CollisionsElastic,
     Particle,
+    Simulation,
 )
 from lib.board import Board
 

--- a/client-py/app/cube.py
+++ b/client-py/app/cube.py
@@ -1,6 +1,4 @@
-import datetime
 import math
-import time
 from dataclasses import dataclass
 
 import config
@@ -76,9 +74,6 @@ class Cube(App):
         TRANSLATEX = (config.WIDTH - 4) // 2 + int(config.WIDTH / 8)
         TRANSLATEY = (config.HEIGHT - 4) // 2 + 4 + 8
 
-        # (!) Try changing this to '#' or '*' or some other character:
-        LINE_CHAR = chr(9608)  # Character 9608 is a solid block.
-
         # (!) Try setting two of these values to zero to rotate the cube only
         # along a single axis:
         K = 0.7
@@ -139,7 +134,7 @@ class Cube(App):
             rotated_z = z
 
             # False perspective
-            k = 1 if ISOMETRIC else 1.5 ** z * 0.6 + 0.25
+            k = 1 if ISOMETRIC else 1.5**z * 0.6 + 0.25
 
             return Point(rotated_x * k, rotated_y * k, rotated_z)
 
@@ -194,8 +189,8 @@ class Cube(App):
         ) -> None:
 
             # Erase old
-            for l in lines:
-                line(l.x1, l.y1, l.x2, l.y2, 0)
+            for ln in lines:
+                line(ln.x1, ln.y1, ln.x2, ln.y2, 0)
             lines.clear()
 
             # Find farthest point to omit hidden edges
@@ -222,8 +217,8 @@ class Cube(App):
 
             # Draw
             self.gfx.set_fg_color(*LINES_RGB)
-            for l in lines:
-                line(l.x1, l.y1, l.x2, l.y2, 1)
+            for ln in lines:
+                line(ln.x1, ln.y1, ln.x2, ln.y2, 1)
 
         self.last_x0 = self.last_x1 = self.last_y0 = self.last_y1 = 0
         self.has_last = False
@@ -256,7 +251,7 @@ class Cube(App):
             for i, face in enumerate(CUBE_FACES):
                 src = corners[face.normal.a]
                 dst = corners[face.normal.b]
-                dx, dy, dz = dst.x - src.x, dst.y - src.y, dst.z - src.z
+                dx, _, dz = dst.x - src.x, dst.y - src.y, dst.z - src.z
                 if dz > 0:
                     visible_faces_indices.add(i)
                     value_by_face_index[i] = (dz + dx) / 3
@@ -288,7 +283,6 @@ class Cube(App):
             top_right = Point2(x1, y0)
             bot_left = Point2(x0, y1)
             bot_right = Point2(x1, y1)
-            center = Point2(TRANSLATEX, TRANSLATEY)
 
             if smart_erase:
                 # erase frame (between enclosing rectangle and last enclosing rectangle)
@@ -474,9 +468,7 @@ class Cube(App):
         # Rotation amounts for each axis:
         rotation = Vector(0, 0, 0)
 
-        previous: Vector | None = None
         escaper = TimeEscaper(self)
-        start = datetime.datetime.now()
         # self.gfx.reset()
 
         lines: list[Line] = []

--- a/client-py/app/monitor_cpus.py
+++ b/client-py/app/monitor_cpus.py
@@ -38,32 +38,31 @@ class MonitorCpus(MonitorBase):
             # CPUs
             self.gfx.set_cursor(0, config.TEXT_SCALING * 12)
             lines = cpus
-            for l in lines:
-                self.gfx.print(f'{l}\\n')
+            for ln in lines:
+                self.gfx.print(f'{ln}\\n')
 
             # Mem
             if len(lines) <= 4:
                 self.gfx.set_cursor(0, config.TEXT_SCALING * 6 * 8)
-                for l in mem:
-                    self.gfx.print(f'{l}\\n')
+                for ln in mem:
+                    self.gfx.print(f'{ln}\\n')
 
             self.gfx.display()
 
     def get_cpus_pcents(self) -> list[str]:
         try:
             out = self.shell_command(
-                (f'mpstat -P ALL {config.MONITOR_CPU_INTERVAL} 1 ' f'-o JSON').split()
+                (f'mpstat -P ALL {config.MONITOR_CPU_INTERVAL} 1 -o JSON').split()
             )
             data = json.loads(out)
             loads = data['sysstat']['hosts'][0]['statistics'][0]['cpu-load']
-            cpus = [l for l in loads if l['cpu'] not in ('all', '-1')]
+            cpus = [entry for entry in loads if entry['cpu'] not in ('all', '-1')]
             pcents = [int(c['usr'] + 0.5) for c in cpus]
 
             pcents.sort(reverse=True)  # DEBATABLE
-        except:
+        except Exception:
             return ['<CPUs: mpstat error>']
         lines = []
-        items_per_line = int(self.chars_per_line / 4)
         line = ''
         for i, pcent in enumerate(pcents):
             line += f'{pcent:3}'

--- a/client-py/app/monitor_graph.py
+++ b/client-py/app/monitor_graph.py
@@ -286,7 +286,6 @@ class MonitorGraph(MonitorBase):
         self.gfx.print(cpus_label)
 
         if state.last_cpus_ttl is not None:
-            xy = self.gfx
             self.gfx.set_text_color(0, 0, 0)
             self.gfx.print(f'{state.last_cpus_ttl}%')
             self.gfx.set_text_color(*COLOR_LABELS)
@@ -294,7 +293,6 @@ class MonitorGraph(MonitorBase):
         self.gfx.set_cursor(0, y + dy)
         self.gfx.print(cpus_label)
         self.gfx.print(f'{state.cpus_ttl}%')
-        last_cpus_ttl = state.cpus_ttl
 
         # Net
         y = self.make_net_y(0)
@@ -325,15 +323,13 @@ class MonitorGraph(MonitorBase):
         try:
             # interval = config.MONITOR_CPU_INTERVAL
             interval = 1
-            out = self.shell_command(
-                (f'mpstat -P ALL {interval} 1 ' f'-o JSON').split()
-            )
+            out = self.shell_command((f'mpstat -P ALL {interval} 1 -o JSON').split())
             data = json.loads(out)
             loads = data['sysstat']['hosts'][0]['statistics'][0]['cpu-load']
-            cpus = [l for l in loads if l['cpu'] not in ('all', '-1')]
+            cpus = [entry for entry in loads if entry['cpu'] not in ('all', '-1')]
             pcents = [int(c['usr'] + 0.5) for c in cpus]
             pcents = sorted(pcents)
-        except:
+        except Exception:
             return [], '<mpstat error>'
         return pcents, ''
 
@@ -343,5 +339,5 @@ class MonitorGraph(MonitorBase):
             rx = sum([int(m) for m in RX_REGEX.findall(out)])
             tx = sum([int(m) for m in TX_REGEX.findall(out)])
             return rx, tx, ''
-        except:
+        except Exception:
             return 0, 0, '<netstat error>'

--- a/client-py/app/monitor_host.py
+++ b/client-py/app/monitor_host.py
@@ -32,7 +32,7 @@ class MonitorBase(App):
             head = '  ' + ''.join([f'{s:3}' for s in cols])
             vals = '   ' + ' '.join([f'{int(v):2}' for v in stats])
             return [head, vals]
-        except:
+        except Exception:
             return ['mem unavailable']
 
     def shell_command(
@@ -44,7 +44,7 @@ class MonitorBase(App):
             return subprocess.run(
                 cmd, encoding='utf-8', check=check, stdout=subprocess.PIPE
             ).stdout
-        except Exception as e:
+        except Exception:
             print(f'Error >>> {cmd}')
             raise
 
@@ -75,9 +75,9 @@ class MonitorHost(MonitorBase):
                 self.get_uptime(),
             ] + self.get_mem()
 
-            for l in lines:
-                l = self.shorten(l)
-                self.gfx.print(f'{l}\\n')
+            for ln in lines:
+                ln = self.shorten(ln)
+                self.gfx.print(f'{ln}\\n')
             self.gfx.display()
 
             btns = self.board.wait_button(2)
@@ -91,7 +91,7 @@ class MonitorHost(MonitorBase):
     def get_hostname(self) -> str:
         try:
             return self.shell_command(['hostname'])
-        except:
+        except Exception:
             return '<hostname unavail>'
 
     def get_ip(self) -> str:
@@ -105,7 +105,7 @@ class MonitorHost(MonitorBase):
             host = config.MONITOR_SSH_AUTHORITY.split('@')[-1]
             out = self.shell_command(['host', host], force_local=True, check=False)
             return out.splitlines()[0].split(' ')[-1]
-        except:
+        except Exception:
             return '<rmt ip addr unavail>'
 
     def get_local_ip(self) -> str:
@@ -113,27 +113,27 @@ class MonitorHost(MonitorBase):
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             s.connect(("8.8.8.8", 80))
             return str(s.getsockname()[0])
-        except:
+        except Exception:
             return '<ip addr unavail>'
 
     def get_nb_users(self) -> int | None:
         try:
             out = self.shell_command(['who'])
             return len(out.splitlines())
-        except:
+        except Exception:
             return None
 
     def get_date(self) -> str:
         try:
             out = self.shell_command(['date', '--rfc-3339=seconds'])
             return out.split('+')[0]
-        except:
+        except Exception:
             return '<date unavail>'
 
     def get_uptime(self) -> str:
         try:
             uptime = self.shell_command(['uptime', '-p'])
-        except:
+        except Exception:
             return '<uptime unavail>'
         for unit in 'hour', 'minute', 'day', 'week', 'month', 'year':
             initial = unit[0]
@@ -150,5 +150,5 @@ class MonitorHost(MonitorBase):
             head = '  ' + ''.join([f'{s:3}' for s in cols])
             vals = '   ' + ' '.join([f'{int(v):2}' for v in stats])
             return [head, vals]
-        except:
+        except Exception:
             return ['mem unavailable']

--- a/client-py/app/road.py
+++ b/client-py/app/road.py
@@ -13,7 +13,6 @@ class Road(App):
         super().__init__(board, auto_read=True)
 
     def _run(self) -> bool:
-        last = None
         escaper = TimeEscaper(self)
 
         i = 0
@@ -39,9 +38,9 @@ class Road(App):
 
     def draw(self, i: int, c: int) -> None:
         i = NB - (i % NB)
-        w = config.WIDTH * K ** i * 2
-        h = config.HEIGHT * K ** i * 2
-        x, y = w / 2, h / 2
+        w = config.WIDTH * K**i * 2
+        h = config.HEIGHT * K**i * 2
+        _, y = w / 2, h / 2
 
         x0 = int(config.WIDTH / 2 - w / 2)
         x1 = int(config.WIDTH / 2 + w / 2)

--- a/client-py/app/starfield.py
+++ b/client-py/app/starfield.py
@@ -4,7 +4,6 @@ import config
 from app import App, TimeEscaper
 from lib.board import Board
 
-
 K = 0.75
 
 
@@ -20,8 +19,8 @@ class Star:
 
     def compute(self, t: int, check: bool = False) -> tuple[int, int] | None:
         dt = float(t - self.t0)
-        x = int(self.vx * self.k ** dt + 0.5 + config.WIDTH / 2)
-        y = int(self.vy * self.k ** dt + 0.5 + config.HEIGHT / 2)
+        x = int(self.vx * self.k**dt + 0.5 + config.WIDTH / 2)
+        y = int(self.vy * self.k**dt + 0.5 + config.HEIGHT / 2)
         if check:
             if x > config.WIDTH or x < 0 or y > config.HEIGHT or y < 0:
                 return None

--- a/client-py/app/tunnel.py
+++ b/client-py/app/tunnel.py
@@ -51,8 +51,8 @@ class Tunnel(App):
 
     def make(self, i: int) -> tuple[int, int]:
         i = NB - 1 - (i % NB)
-        w = int(config.WIDTH * K ** i * 2)
-        h = int(config.HEIGHT * K ** i * 2)
+        w = int(config.WIDTH * K**i * 2)
+        h = int(config.HEIGHT * K**i * 2)
         return w, h
 
     def compute(

--- a/client-py/lib/args.py
+++ b/client-py/lib/args.py
@@ -41,7 +41,7 @@ def get_args(all_apps: list[Type[App]]) -> tuple[argparse.Namespace, list[Type[A
 
     # make config.py declarations accessible as args
     for spec in specs:
-        if spec.type == bool:
+        if spec.type is bool:
             parser.add_argument(spec.as_flag, action='store_true')
         else:
             parser.add_argument(
@@ -50,7 +50,6 @@ def get_args(all_apps: list[Type[App]]) -> tuple[argparse.Namespace, list[Type[A
                 metavar=spec.type.__name__.upper(),
                 help=f'default: {spec.value}',
             )
-    existing = [spec.as_flag for spec in specs]
 
     # make --only arg
     possible_apps: list[str] = []
@@ -59,7 +58,7 @@ def get_args(all_apps: list[Type[App]]) -> tuple[argparse.Namespace, list[Type[A
         name = camel_to_kebab(name)
         possible_apps.append(name)
     parser.add_argument(
-        f'--only',
+        '--only',
         nargs='+',
         metavar="APP",
         help='list of apps to run, among: ' + ' '.join(possible_apps),

--- a/client-py/lib/board.py
+++ b/client-py/lib/board.py
@@ -4,7 +4,7 @@ import time
 from typing import Any, Callable
 
 import config
-from lib import NONE, READY, until, chunkize
+from lib import NONE, READY, chunkize, until
 from lib.gfx import Gfx
 
 from .channel import Channel
@@ -64,7 +64,7 @@ class Board:
         # normally called by callback
         try:
             self._configure()
-        except:
+        except Exception:
             self.reboot()
             self._configure()
 
@@ -82,7 +82,7 @@ class Board:
             config.HEIGHT = h
             config.COLUMNS = int(w / 6.4)
             config.ROWS = int(h / 8)
-            print(f'OLED resolution:')
+            print('OLED resolution:')
             print(f'  pixels: {w} x {h}')
             print(f'  chars:  {config.COLUMNS} x {config.ROWS}')
 
@@ -214,7 +214,6 @@ class Board:
         print(msg)
         self.gfx.reset()
         self.gfx.set_auto_display_on()
-        w, h = 1, config.TEXT_SCALING
         self.gfx.set_text_size(0.5, 1)
         self.gfx.set_text_wrap_on()
 

--- a/client-py/lib/channel.py
+++ b/client-py/lib/channel.py
@@ -4,9 +4,7 @@ from typing import Any, Callable
 import serial  # pip3 install pyserial
 
 import config
-from lib import *
-from lib import ArduinoCommExceptions
-import sys
+from lib import ASCII, ArduinoCommExceptions
 
 
 class Channel:
@@ -98,7 +96,7 @@ class Channel:
                     c = b''
                 try:
                     c = c.decode('ascii')
-                except:
+                except Exception:
                     pass
                 if config.DEBUG:
                     print(c, end='')

--- a/client-py/lib/command.py
+++ b/client-py/lib/command.py
@@ -2,7 +2,7 @@ import time
 from typing import Callable
 
 import config
-from lib import NONE, ERROR, UNKNOWN, ArduinoCommExceptions
+from lib import ERROR, NONE, UNKNOWN, ArduinoCommExceptions
 
 from .channel import Channel
 
@@ -32,7 +32,7 @@ class Command:
         # it is okay to retry once
         try:
             return self._send_command(cmd, ignore_error, ignore_response)
-        except:
+        except Exception:
             self.chan.clear()
             return self._send_command(cmd, ignore_error, ignore_response)
 
@@ -57,7 +57,7 @@ class Command:
         time.sleep(delay)
         try:
             self.chan.close()
-        except:
+        except Exception:
             pass
 
         self.chan.open()

--- a/client-py/lib/gfx.py
+++ b/client-py/lib/gfx.py
@@ -104,10 +104,10 @@ class Gfx:
         self._command('autoDisplay 0')
 
     def get_width(self) -> int:
-        return int(self._command(f'width'))
+        return int(self._command('width'))
 
     def get_height(self) -> int:
-        return int(self._command(f'height'))
+        return int(self._command('height'))
 
     def read_buttons(self) -> str:
         btns = self._command('readButtons', ignore_error=True)

--- a/client-py/pyproject.toml
+++ b/client-py/pyproject.toml
@@ -1,3 +1,8 @@
-[tool.black]
-skip-string-normalization = true
-target-version = ['py310']
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+extend-select = ["I"] # isort import ordering
+
+[tool.ruff.format]
+quote-style = "preserve" # was Black skip-string-normalization

--- a/client-py/run.py
+++ b/client-py/run.py
@@ -8,6 +8,7 @@ from typing import Any, Type
 import config
 from app import App
 from app.asteriods import Asteriods
+from app.claude_mon import ClaudeMonitor
 
 # from app.bumps import Bumps
 from app.collisions import CollisionsElastic
@@ -20,9 +21,7 @@ from app.monitor_cpus import MonitorCpus
 from app.monitor_graph import MonitorGraph
 from app.monitor_host import MonitorHost
 from app.quix import Quix
-from app.road import Road
 from app.starfield import Starfield
-from app.claude_mon import ClaudeMonitor
 from app.thats_all import ThatsAll
 from app.tunnel import Tunnel
 from lib import ArduinoCommExceptions, RebootedException
@@ -37,10 +36,10 @@ def make_board(chan: Channel) -> Board:
         # board.wait_configured()
         board.clear_buttons()
         return board
-    except ArduinoCommExceptions as e:
+    except ArduinoCommExceptions:
         try:
             chan.close()
-        except:
+        except Exception:
             pass
         raise
 
@@ -125,7 +124,7 @@ while True:
         board.fatal('Keyboard interrupt')
         suppress_ctrl_c()
         raise
-    except Exception as e:
+    except Exception:
         msg = traceback.format_exc()
         board.fatal(msg)
 

--- a/devlog/0009-ruff.md
+++ b/devlog/0009-ruff.md
@@ -1,0 +1,103 @@
+# 0009 — Adopt ruff (format + lint), drop mypy
+
+- GH issue: #9
+- Branch: impl/0009-ruff
+- Opened: 2026-06-27
+- Closed: 2026-06-27
+
+Standard-flow task (behaviour-affecting; no test coverage yet). Scope from `TODO.md` item 2.
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+Adopt ruff as the single quality tool for `client-py` (format + lint) and drop mypy, per `TODO.md` item 2 and the user's "strict / clean" policy choice.
+
+### Acceptance criteria
+
+1. `[tool.ruff]` config in `client-py/pyproject.toml`; Black config removed.
+2. `ruff format` applied across `client-py`.
+3. `ruff check` (default E/F + isort I) reports zero findings — all 57 fixed, not ignored.
+4. mypy removed from the top-level `Makefile` (`lint`/`clean` use ruff).
+5. All modules still parse.
+
+### Policy decision (user)
+
+"Strict / clean": fix every finding rather than ignore rules. Includes behaviour-affecting changes (bare-except scope) — accepted knowingly, to be reviewed before merge.
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+1. Add `[tool.ruff]` (target py310, isort, `quote-style = preserve` to match the prior Black `skip-string-normalization`).
+2. `ruff check --fix` (safe) + `ruff format`.
+3. Manual fixes for the rest:
+   - 16× bare `except:` → `except Exception:`.
+   - 8× ambiguous `l` → `ln` / `entry`.
+   - 12× unused locals removed (or `_` for unpacking).
+   - 1× `type ==` → `is` (`lib/args.py`).
+   - star-import `from lib import *` → explicit `from lib import ASCII, ArduinoCommExceptions` (`lib/channel.py`).
+4. Rewrite top-level `Makefile` (interim ruff targets; full uv rewrite deferred to task G).
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 Deviations
+
+- Removing `start = datetime.datetime.now()` in `cube.py` orphaned `import datetime`, auto-removed by a follow-up `ruff check --fix`.
+- Dead apps `road.py` (and `bumps.py`) were linted/fixed too (unused locals) — they stay unlinked but kept green so `ruff check .` passes whole-tree.
+
+### 3.2 Behaviour change (review focus)
+
+Converting bare `except:` to `except Exception:` lets `KeyboardInterrupt`/`SystemExit` propagate where they were previously swallowed. This is behaviour-affecting and **may interact with open issue #3 (Ctrl-C handling)** — likely an improvement (Ctrl-C now breaks loops), but unverified without hardware. Sites: `monitor_host.py` (8), `monitor_cpus.py`, `monitor_graph.py` (2), `lib/board.py`, `lib/channel.py`, `lib/command.py` (2), `run.py`.
+
+### 3.3 Verification
+
+- `make lint` → `All checks passed!` + `26 files already formatted`.
+- `python3 -c "ast.parse(...)"` over all `client-py/**/*.py` → parse OK.
+- No runtime/hardware test (no board; tests are tasks D/E).
+
+### 3.4 Retrospective
+
+| #   | Point                                                          | Agent | User |
+| --- | -------------------------------------------------------------- | ----- | ---- |
+| 1   | Strict policy surfaced a real behaviour change (except scope)  | well  |      |
+| 2   | No tests yet to confirm behaviour preserved — reviewed instead | surprise |   |
+| 3   | quote-style=preserve kept the format diff small                | well  |      |
+
+### 3.5 Verdict
+
+Accept with reservation: behaviour-change sites (3.2) want a human eye and, later, test coverage (task E).
+
+## Governance trace
+
+| Source           | Clause                  | Action  | Note                                        |
+| ---------------- | ----------------------- | ------- | ------------------------------------------- |
+| CLAUDE.md (Criticality) | criticality assessment | applied | escalated to standard flow on behaviour risk |
+| CEREMONIES.md (fast-path fallback) | fast-path fallback | applied | reverted Q from fast-path to reviewed flow  |
+| CLAUDE.md (Multiple interpretations) | lint policy choice | applied | surfaced 3 options; user picked strict/clean |
+
+## Resource consumption
+
+| Phase     | Tokens (approx) | Wall time |
+| --------- | --------------- | --------- |
+| Mandate   | ~6k             | 5 min     |
+| Execution | ~40k            | 35 min    |
+| Closure   | ~6k             | 5 min     |
+| **Total** | **~52k**        | **~45 min** |
+
+| Counter                | Value |
+| ---------------------- | ----- |
+| Pre-commit hook fails  | 0     |
+| Subagent invocations   | 0     |
+| `/clear` events        | 0     |
+| Memory rotation events | 0     |
+| LOC changed            | ~81 insertions / ~105 deletions |
+| Files changed          | 21    |


### PR DESCRIPTION
TODO item 2 / task Q. Quality tooling — **strict/clean** policy (your choice).

## Changes
- `client-py/pyproject.toml`: Black config → `[tool.ruff]` (isort, `quote-style=preserve`, py310)
- `ruff format` across `client-py`; **all 57 `ruff check` findings fixed** (not ignored)
- top-level `Makefile`: mypy dropped; interim ruff `lint`/`format`/`clean` (full uv rewrite is task G)
- devlog `devlog/0009-ruff.md`

## Review focus — behaviour change
16 bare `except:` → `except Exception:`. This lets `KeyboardInterrupt`/`SystemExit` propagate where previously swallowed — **may interact with #3 (Ctrl-C handling)**, likely an improvement but unverified (no board, no tests yet → tasks D/E).

## Verification
`make lint` → `All checks passed!`; all `client-py/**/*.py` parse.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)