### PR TITLE
[impl] Add per-subproject READMEs; tidy doc cross-linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ an ESP32-S3 board with a 240×135 colour TFT on its back.
 
 This repository provides all three parts:
 
-- **`server-esp32s3-rtft/`** — the Arduino firmware sketch (C++): a graphical server exposing TFT drawing primitives and button readout over USB; holds no app logic.
-- **`client-py/`** — the Python client (Linux): owns all app logic and the ready-to-run apps; drives the board by sending command lines and reading answers.
-- **`case-esp32s3-rtft/`** — the OpenSCAD 3D-printed case and cap.
+- **[`server-esp32s3-rtft/`](server-esp32s3-rtft/)** — the Arduino firmware sketch (C++): a graphical server exposing TFT drawing primitives and button readout over USB; holds no app logic.
+- **[`client-py/`](client-py/)** — the Python client (Linux): owns all app logic and the ready-to-run apps; drives the board by sending command lines and reading answers.
+- **[`case-esp32s3-rtft/`](case-esp32s3-rtft/)** — the OpenSCAD 3D-printed case and cap.
 
 The board maps most commands directly to TFT library calls; the contract
 between the two sides is the [USB protocol](README-protocol.md).

--- a/case-esp32s3-rtft/README.md
+++ b/case-esp32s3-rtft/README.md
@@ -1,0 +1,19 @@
+# case-esp32s3-rtft — 3D-printed case
+
+The enclosure of the [Arduino ESP32 TFT Terminal](../README.md): a 3D-printed
+case and cap for the
+[Adafruit ESP32-S3 Reverse TFT Feather](https://www.adafruit.com/product/5345),
+designed in [OpenSCAD](https://openscad.org/).
+
+## Files
+
+- `esp32s3-rtft-case.scad` / `esp32s3-rtft-case.stl` — the case (source / printable).
+- `esp32s3-rtft-cap.scad` / `esp32s3-rtft-cap.stl` — the cap (source / printable).
+
+## Printing
+
+- Slice and print the `.stl` files with your usual slicer and filament.
+
+## Customising
+
+- Edit the `.scad` sources in OpenSCAD, then export fresh `.stl` files.

--- a/client-py/README.md
+++ b/client-py/README.md
@@ -1,0 +1,40 @@
+# client-py — Python client
+
+The computer-side program of the
+[Arduino ESP32 TFT Terminal](../README.md). It owns all application logic and
+drives the board over USB, sending command lines and reading answers.
+
+## Requirements
+
+- Python 3.10+ on Linux.
+- A flashed board (see [`../server-esp32s3-rtft/`](../server-esp32s3-rtft/)) connected over USB.
+- Dependencies: `numpy`, `pyserial`, `claude-busy-monitor`.
+
+## Running
+
+From source (a pip/uv-installable package is on the way — see [`../TODO.md`](../TODO.md)):
+
+```bash
+pip install -r requirements.txt
+./run.py -h           # list options and apps
+./run.py --demo       # cycle through all apps
+./run.py --only cube  # run a single app
+```
+
+## Layout
+
+- `app/` — one module + class per app (`quix.py` is the template).
+- `lib/` — board communication: serial channel, command protocol, `Board`, `Gfx`, CLI args.
+- `run.py` — entry point; registers the apps.
+- `config.py` — runtime configuration (also exposed as CLI flags).
+
+## Writing a new app
+
+1. Study [`app/quix.py`](app/quix.py) as a template.
+2. Create a new module and class.
+3. Register the class in [`run.py`](run.py).
+
+## Development
+
+- Format + lint with [ruff](https://docs.astral.sh/ruff/): `make format` / `make lint` (from the repo root).
+- See the top-level [README](../README.md) and [`../TODO.md`](../TODO.md) for the wider toolchain.

--- a/devlog/0015-subproject-readmes.md
+++ b/devlog/0015-subproject-readmes.md
@@ -1,0 +1,75 @@
+# 0015 — Per-subproject READMEs; tidy doc cross-linking
+
+- GH issue: #15
+- Branch: impl/0015-subproject-readmes
+- Opened: 2026-06-27
+- Closed: 2026-06-27
+
+Fast-path task (doc-only). Scope from `TODO.md` item 4 (H2b + H2c).
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+Add a README to each subproject and make the doc family coherently indexed.
+
+### Acceptance criteria
+
+1. `client-py/README.md`, `server-esp32s3-rtft/README.md`, `case-esp32s3-rtft/README.md` exist.
+2. Each links back to the top README and the relevant `README-*` docs.
+3. Top README's three-parts bullets link into each subproject (top README = doc index).
+4. All links resolve.
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+1. Write three bullet-first subproject READMEs (purpose, requirements/build, layout, cross-links).
+2. Link the top README's three-parts bullets to the subproject directories.
+3. Keep `client-py/README.md` usage-focused (its layout changes in packaging/Task P).
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 Deviations
+
+- **H2c done without moving files**: the top README's Documentation section + the new subproject cross-links already form the index. Moving `README-protocol`/`README-animations`/`README-VSCODE` into a `docs/` folder was rejected (YAGNI — breaks URLs and history for no gain).
+
+### 3.3 Verification
+
+- All inter-file links in the new READMEs and the top README verified to resolve on disk.
+
+### 3.4 Retrospective
+
+| #   | Point                                                       | Agent | User |
+| --- | ----------------------------------------------------------- | ----- | ---- |
+| 1   | client-py README kept usage-focused to survive the P restructure | well |   |
+| 2   | No file moves for H2c (index already emergent)              | well  |      |
+
+### 3.5 Verdict
+
+Accept.
+
+## Governance trace
+
+| Source                             | Clause             | Action  | Note                          |
+| ---------------------------------- | ------------------ | ------- | ----------------------------- |
+| CEREMONIES.md (doc-only carve-out) | doc-only fast-path | applied | slim devlog                   |
+| CLAUDE.md (YAGNI)                  | YAGNI              | applied | no `docs/` move for H2c       |
+
+## Resource consumption
+
+| Phase | Tokens (approx) | Wall time |
+| ----- | --------------- | --------- |
+| Total | ~12k            | ~12 min   |
+
+| Counter       | Value |
+| ------------- | ----- |
+| Files changed | 5     |

--- a/server-esp32s3-rtft/README.md
+++ b/server-esp32s3-rtft/README.md
@@ -1,0 +1,28 @@
+# server-esp32s3-rtft — board firmware
+
+The board-side firmware of the
+[Arduino ESP32 TFT Terminal](../README.md). It is a graphical server (C++):
+it exposes the TFT drawing primitives and button readout over USB, and holds
+no application logic — all behaviour lives in the [Python client](../client-py/).
+
+## Hardware
+
+- [Adafruit ESP32-S3 Reverse TFT Feather](https://www.adafruit.com/product/5345) (ESP32-S3 + 240×135 colour TFT).
+
+## Building and uploading
+
+- Built and uploaded with VS Code + the Arduino extension — see [`README-VSCODE.md`](README-VSCODE.md).
+
+## Protocol
+
+- The computer sends textual commands; the board answers. Most commands map directly to TFT library calls.
+- Specified in [`../README-protocol.md`](../README-protocol.md).
+
+## Layout
+
+- `server-esp32s3-rtft.ino` — main loop: read a command line, interpret it, answer.
+- `command.cpp` / `command.h` — parse and dispatch commands (compile-time string hashing).
+- `transaction.cpp` / `transaction.h` — buffered action execution.
+- `esp32s3-display.cpp` / `esp32s3-display.h` — TFT primitives over Adafruit ST7789 + buttons.
+- `neopixel.cpp` / `neopixel.h` — on-board NeoPixel LED.
+- `config.h` — buffer sizing and board configuration.


### PR DESCRIPTION
TODO item 4 (H2b + H2c). Doc-only.

- New `client-py/`, `server-esp32s3-rtft/`, `case-esp32s3-rtft/` READMEs (bullet-first; purpose, build/run, layout, cross-links).
- Top README three-parts bullets now link into each subproject → top README serves as the doc index.
- H2c: no file moves (YAGNI; the index is already emergent).
- All links verified to resolve.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)