### PR TITLE
[impl] On-board self-test: primitive gallery + buttons (make test-board)

### DIFF
--- a/client-py/Makefile
+++ b/client-py/Makefile
@@ -64,9 +64,14 @@ format: ## ruff format + lint autofix (modifies code)
 	uv run ruff check --fix src tests
 
 .PHONY: test
-test: ## run unit tests
+test: ## run host unit tests (no board)
 	uv sync --extra dev
 	uv run pytest tests
+
+.PHONY: test-board
+test-board: ## on-board acceptance suite (needs gadget on USB; not CI)
+	uv sync --extra dev
+	uv run python -m arduino_esp32_tft_terminal.selftest
 
 .PHONY: check
 check: lint test ## CI/pre-PR gate: lint test

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -36,33 +36,36 @@ class Results:
     def __init__(self) -> None:
         self.checks: list[tuple[str, bool, str]] = []
 
-    def check(self, name: str, ok: bool, detail: str = '') -> None:
+    def check(self, name: str, ok: bool, detail: str = "") -> None:
+        # The test ID is already printed as the title (see _title); show result.
         self.checks.append((name, ok, detail))
-        mark = 'PASS' if ok else 'FAIL'
-        print(f'  [{mark}] {name}' + (f' — {detail}' if detail else ''))
+        mark = "PASS" if ok else "FAIL"
+        print(f"  -> {mark}" + (f" ({detail})" if detail else ""))
 
     @property
     def ok(self) -> bool:
         return all(ok for _, ok, _ in self.checks)
 
     def summary(self) -> None:
+        print("\n=== summary ===")
+        for name, ok, detail in self.checks:
+            mark = "PASS" if ok else "FAIL"
+            line = f"  {mark}  {name}"
+            if not ok and detail:
+                line += f"  ({detail})"
+            print(line)
         passed = sum(1 for _, ok, _ in self.checks if ok)
-        total = len(self.checks)
-        print(f'\nself-test: {passed}/{total} checks passed.')
-        if not self.ok:
-            print('Failed:')
-            for name, ok, detail in self.checks:
-                if not ok:
-                    print(f'  - {name}' + (f' ({detail})' if detail else ''))
+        verdict = "ALL PASS" if self.ok else "FAILURES"
+        print(f"\n  {passed}/{len(self.checks)} passed — {verdict}")
 
 
 def connect() -> Board:
     """Open the serial port and configure the board (blocks until present)."""
-    print('Connecting to the board over USB...')
+    print("Connecting to the board over USB...")
     board = Board(Channel())
     board.configure()
     assert config.WIDTH and config.HEIGHT
-    print(f'Connected: {config.WIDTH}x{config.HEIGHT}.')
+    print(f"Connected: {config.WIDTH}x{config.HEIGHT}.")
     return board
 
 
@@ -72,7 +75,7 @@ def connect() -> Board:
 
 
 def _ask(prompt: str) -> bool:
-    return input(f'{prompt} [y/N] ').strip().lower().startswith('y')
+    return input(f"{prompt} [y/N] ").strip().lower().startswith("y")
 
 
 def _gallery_shapes(gfx: Gfx) -> None:
@@ -107,16 +110,16 @@ def _gallery_text(gfx: Gfx) -> None:
     gfx.set_text_color(255, 255, 255)
     gfx.set_text_size(1, 1)
     gfx.set_cursor(0, 0)
-    gfx.print('top-left')
+    gfx.print("top-left")
     # middle, double size
     gfx.set_text_size(2, 2)
     gfx.set_text_color(255, 255, 0)
     gfx.set_cursor(0, h // 3)
-    gfx.print('SIZE 2')
+    gfx.print("SIZE 2")
     # bottom-right, measured with getTextBounds and right/bottom-aligned
     gfx.set_text_size(1, 1)
     gfx.set_text_color(0, 255, 255)
-    label = 'bottom-right'
+    label = "bottom-right"
     tw, th = gfx.get_text_bounds(0, 0, label)
     gfx.set_cursor(max(0, w - tw), max(0, h - th))
     gfx.print(label)
@@ -143,11 +146,13 @@ def _gallery_frame(gfx: Gfx) -> None:
 
 
 _SHAPES_REF = """\
-    ╲         □■     ○●
-     ╲
-               ·     │
-               ──────+─
-    ◣  ◢             │
+  ┌────────────────────┐
+  │ ╲      □■    ○●    │
+  │  ╲                 │
+  │          ·   │     │
+  │          ────┼─    │
+  │ ◣ ◢          │     │
+  └────────────────────┘
 """
 
 _TEXT_REF = """\
@@ -162,34 +167,38 @@ _TEXT_REF = """\
 
 GALLERY: list[tuple[str, Callable[[Gfx], None], str, str]] = [
     (
-        'shapes',
+        "shapes",
         _gallery_shapes,
-        'do the shapes match the reference (all present, placed alike)?',
+        "do the shapes match the reference (all present, placed alike)?",
         _SHAPES_REF,
     ),
     (
-        'text',
+        "text",
         _gallery_text,
-        'do the labels match the reference (text, size, colour, position)?',
+        "do the labels match the reference (text, size, colour, position)?",
         _TEXT_REF,
     ),
     (
-        'frame',
+        "frame",
         _gallery_frame,
-        'a 1px border touching all four edges + an even interior crosshatch?',
-        '',
+        "a 1px border touching all four edges + an even interior crosshatch?",
+        "",
     ),
 ]
 
 
+def _title(test_id: str) -> None:
+    print(f"\n=== {test_id} ===")
+
+
 def phase1_gallery(board: Board, results: Results) -> None:
-    print('\n== Phase 1a: primitive gallery (glance check) ==')
     for name, draw, question, reference in GALLERY:
+        _title(f"gallery:{name}")
         draw(board.gfx)
         if reference:
-            print('  expected layout:')
+            print("  expected layout:")
             print(reference)
-        results.check(f'gallery:{name}', _ask(question))
+        results.check(f"gallery:{name}", _ask(question))
 
 
 # Seconds to wait for each interactive button press (None = wait forever).
@@ -219,28 +228,29 @@ def _await_auto_button(
 def phase1_buttons(board: Board, results: Results) -> None:
     # Buttons via auto-report mode (the path the apps use): once enabled, the
     # board appends button codes to every OK response.
-    print('\n== Phase 1b: buttons — press the button ON THE GADGET ==')
     gfx = board.gfx
     board.clear_buttons()  # reset reboot counter so `R` isn't reported spuriously
     board.begin_auto_read_buttons()
     try:
-        for code, label in [('A', 'A (D0)'), ('B', 'B (D1)'), ('C', 'C (D2)')]:
+        for code, label in [("A", "A (D0)"), ("B", "B (D1)"), ("C", "C (D2)")]:
+            _title(f"button:{code}")
             gfx.reset()
             gfx.fill_screen(0)
             gfx.set_text_color(255, 255, 255)
             gfx.set_text_size(2, 2)
             gfx.set_cursor(0, config.HEIGHT // 3)
-            gfx.print(f'PRESS {code}')
+            gfx.print(f"PRESS {code}")
             gfx.display()
-            print(f'  >>> press button {label}')
+            print(f"  >>> press button {label}")
             seen = _await_auto_button(board, code)
             results.check(
-                f'button:{code}', code in seen, f'saw {sorted(seen) or "nothing"}'
+                f"button:{code}", code in seen, f'saw {sorted(seen) or "nothing"}'
             )
             time.sleep(0.5)  # let the user release before the next prompt
     finally:
         board.end_auto_read_buttons()
 
+    _title("button:reset")
     # Show the RESET prompt on the TFT (replaces the last "PRESS X" screen).
     # "PRESS RESET" doesn't fit on one line at this size, so stack it.
     gfx.reset()
@@ -248,23 +258,23 @@ def phase1_buttons(board: Board, results: Results) -> None:
     gfx.set_text_color(255, 255, 255)
     gfx.set_text_size(2, 2)
     gfx.set_cursor(0, config.HEIGHT // 4)
-    gfx.print('PRESS')
+    gfx.print("PRESS")
     gfx.set_cursor(0, config.HEIGHT // 2)
-    gfx.print('RESET')
+    gfx.print("RESET")
     gfx.display()
-    print('  >>> press the RESET button (the board reboots)')
+    print("  >>> press the RESET button (the board reboots)")
     board.clear_buttons()
     deadline = None if BUTTON_TIMEOUT is None else time.time() + BUTTON_TIMEOUT
     detected = False
     while deadline is None or time.time() < deadline:
         try:
-            if 'R' in board.read_buttons():
+            if "R" in board.read_buttons():
                 detected = True
                 break
         except Exception:
             pass  # serial may drop across the reset; recovery re-opens
         time.sleep(0.2)
-    results.check('button:reset', detected, 'reset -> reboot reported as R')
+    results.check("button:reset", detected, "reset -> reboot reported as R")
 
 
 # ----------------------------------------------------------------------------
@@ -272,53 +282,57 @@ def phase1_buttons(board: Board, results: Results) -> None:
 # ----------------------------------------------------------------------------
 
 PRIMITIVES: list[tuple[str, Callable[[Gfx], None]]] = [
-    ('reset', lambda g: g.reset()),
-    ('fillScreen', lambda g: g.fill_screen(0)),
-    ('setFgColor', lambda g: g.set_fg_color(255, 0, 0)),
-    ('setBgColor', lambda g: g.set_bg_color(0, 0, 32)),
-    ('drawPixel', lambda g: g.draw_pixel(5, 5, 1)),
-    ('drawLine', lambda g: g.draw_line(0, 0, 50, 30, 1)),
-    ('drawRect', lambda g: g.draw_rect(2, 2, 40, 20, 1)),
-    ('fillRect', lambda g: g.fill_rect(2, 2, 40, 20, 1)),
-    ('drawCircle', lambda g: g.draw_circle(30, 30, 15, 1)),
-    ('fillCircle', lambda g: g.fill_circle(30, 30, 15, 1)),
-    ('drawTriangle', lambda g: g.draw_triangle(0, 0, 20, 0, 10, 20, 1)),
-    ('fillTriangle', lambda g: g.fill_triangle(0, 0, 20, 0, 10, 20, 1)),
-    ('drawFastHLine', lambda g: g.draw_fast_hline(0, 10, 50, 1)),
-    ('drawFastVLine', lambda g: g.draw_fast_vline(10, 0, 40, 1)),
-    ('setTextSize', lambda g: g.set_text_size(1, 1)),
-    ('setTextColor', lambda g: g.set_text_color(255, 255, 255)),
-    ('setCursor', lambda g: g.set_cursor(0, 0)),
-    ('setTextWrapOn', lambda g: g.set_text_wrap_on()),
-    ('setTextWrapOff', lambda g: g.set_text_wrap_off()),
-    ('home', lambda g: g.home()),
-    ('print', lambda g: g.print('selftest')),
-    ('clear', lambda g: g.clear()),
-    ('setRotation', lambda g: g.set_rotation(config.SCREEN_ROTATION)),
-    ('display', lambda g: g.display()),
+    ("reset", lambda g: g.reset()),
+    ("fillScreen", lambda g: g.fill_screen(0)),
+    ("setFgColor", lambda g: g.set_fg_color(255, 0, 0)),
+    ("setBgColor", lambda g: g.set_bg_color(0, 0, 32)),
+    ("drawPixel", lambda g: g.draw_pixel(5, 5, 1)),
+    ("drawLine", lambda g: g.draw_line(0, 0, 50, 30, 1)),
+    ("drawRect", lambda g: g.draw_rect(2, 2, 40, 20, 1)),
+    ("fillRect", lambda g: g.fill_rect(2, 2, 40, 20, 1)),
+    ("drawCircle", lambda g: g.draw_circle(30, 30, 15, 1)),
+    ("fillCircle", lambda g: g.fill_circle(30, 30, 15, 1)),
+    ("drawTriangle", lambda g: g.draw_triangle(0, 0, 20, 0, 10, 20, 1)),
+    ("fillTriangle", lambda g: g.fill_triangle(0, 0, 20, 0, 10, 20, 1)),
+    ("drawFastHLine", lambda g: g.draw_fast_hline(0, 10, 50, 1)),
+    ("drawFastVLine", lambda g: g.draw_fast_vline(10, 0, 40, 1)),
+    ("setTextSize", lambda g: g.set_text_size(1, 1)),
+    ("setTextColor", lambda g: g.set_text_color(255, 255, 255)),
+    ("setCursor", lambda g: g.set_cursor(0, 0)),
+    ("setTextWrapOn", lambda g: g.set_text_wrap_on()),
+    ("setTextWrapOff", lambda g: g.set_text_wrap_off()),
+    ("home", lambda g: g.home()),
+    ("print", lambda g: g.print("selftest")),
+    ("clear", lambda g: g.clear()),
+    ("setRotation", lambda g: g.set_rotation(config.SCREEN_ROTATION)),
+    ("display", lambda g: g.display()),
 ]
 
 
 def phase2_unattended(board: Board, results: Results) -> None:
-    print('\n== Phase 2: unattended protocol conformance ==')
     gfx = board.gfx
 
     # Every client primitive must dispatch without an ERROR response.
     for name, call in PRIMITIVES:
+        _title(f"cmd:{name}")
         try:
             call(gfx)
-            results.check(f'cmd:{name}', True)
+            results.check(f"cmd:{name}", True)
         except Exception as e:
-            results.check(f'cmd:{name}', False, str(e))
+            results.check(f"cmd:{name}", False, str(e))
 
     # Queries return sane values.
-    results.check('query:width', gfx.get_width() > 0)
-    results.check('query:height', gfx.get_height() > 0)
-    w, h = gfx.get_text_bounds(0, 0, 'Hi')
-    results.check('query:getTextBounds', w > 0 and h > 0, f'{w}x{h}')
+    _title("query:width")
+    results.check("query:width", gfx.get_width() > 0)
+    _title("query:height")
+    results.check("query:height", gfx.get_height() > 0)
+    _title("query:getTextBounds")
+    w, h = gfx.get_text_bounds(0, 0, "Hi")
+    results.check("query:getTextBounds", w > 0 and h > 0, f"{w}x{h}")
 
     # Short soak: cycle drawing, assert no comm errors / spurious reboots.
-    print('  soak: drawing for 5s...')
+    _title("soak")
+    print("  drawing for 5s...")
     boots_before = board.boots
     errors = 0
     end = time.time() + 5
@@ -331,8 +345,8 @@ def phase2_unattended(board: Board, results: Results) -> None:
             i += 1
         except Exception:
             errors += 1
-    results.check('soak:no-comm-errors', errors == 0, f'{errors} errors')
-    results.check('soak:no-spurious-reboot', board.boots == boots_before)
+    results.check("soak:no-comm-errors", errors == 0, f"{errors} errors")
+    results.check("soak:no-spurious-reboot", board.boots == boots_before)
 
 
 def _show_done(board: Board, ok: bool) -> None:
@@ -343,19 +357,19 @@ def _show_done(board: Board, ok: bool) -> None:
     gfx.set_text_size(1, 1)
     gfx.set_text_color(255, 255, 255)
     gfx.set_cursor(0, config.HEIGHT // 4)
-    gfx.print('Self-test done')
+    gfx.print("All tests done")
     gfx.set_text_size(2, 2)
     if ok:
         gfx.set_text_color(0, 255, 0)
     else:
         gfx.set_text_color(255, 0, 0)
     gfx.set_cursor(0, config.HEIGHT // 2)
-    gfx.print('PASS' if ok else 'FAIL')
+    gfx.print("PASS" if ok else "FAIL")
     gfx.display()
 
 
 def main() -> None:
-    unattended_only = '--unattended-only' in sys.argv
+    unattended_only = "--unattended-only" in sys.argv
     board = connect()
     results = Results()
     if not unattended_only:
@@ -364,9 +378,8 @@ def main() -> None:
     phase2_unattended(board, results)
     results.summary()
     _show_done(board, results.ok)
-    print('\nAll tests complete.')
     sys.exit(0 if results.ok else 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -79,6 +79,21 @@ def _ask(prompt: str) -> bool:
     return input(f"{prompt} [y/N] ").strip().lower().startswith("y")
 
 
+def _prompt_screen(gfx: Gfx, *lines: str) -> None:
+    """Draw stacked size-2 prompt lines on the TFT (e.g. 'PRESS A', or
+    'PRESS' / 'RESET' when it doesn't fit on one line)."""
+    gfx.reset()
+    gfx.fill_screen(0)
+    gfx.set_text_color(255, 255, 255)
+    gfx.set_text_size(2, 2)
+    y = config.HEIGHT // 4
+    for line in lines:
+        gfx.set_cursor(0, y)
+        gfx.print(line)
+        y += config.HEIGHT // 4
+    gfx.display()
+
+
 def _gallery_shapes(gfx: Gfx) -> None:
     # Coordinates derive from the queried resolution so the screen fits any
     # board (the USB protocol is board-agnostic; only W/H and colour differ).
@@ -217,6 +232,7 @@ def phase0_boot(board: Board, results: Results) -> None:
     # the board into USB-disk/bootloader mode. The channel layer reopens the TTY
     # when the board comes back.
     _title("boot:logo")
+    _prompt_screen(board.gfx, "PRESS", "RESET")
     print("  >>> press the RESET button now (the board reboots)")
     print("  expected boot screen:")
     print(_LOGO_REF)
@@ -269,13 +285,7 @@ def phase1_buttons(board: Board, results: Results) -> None:
     try:
         for code, label in [("A", "A (D0)"), ("B", "B (D1)"), ("C", "C (D2)")]:
             _title(f"button:{code}")
-            gfx.reset()
-            gfx.fill_screen(0)
-            gfx.set_text_color(255, 255, 255)
-            gfx.set_text_size(2, 2)
-            gfx.set_cursor(0, config.HEIGHT // 3)
-            gfx.print(f"PRESS {code}")
-            gfx.display()
+            _prompt_screen(gfx, f"PRESS {code}")
             print(f"  >>> press button {label}")
             seen = _await_auto_button(board, code)
             results.check(
@@ -286,17 +296,7 @@ def phase1_buttons(board: Board, results: Results) -> None:
         board.end_auto_read_buttons()
 
     _title("button:reset")
-    # Show the RESET prompt on the TFT (replaces the last "PRESS X" screen).
-    # "PRESS RESET" doesn't fit on one line at this size, so stack it.
-    gfx.reset()
-    gfx.fill_screen(0)
-    gfx.set_text_color(255, 255, 255)
-    gfx.set_text_size(2, 2)
-    gfx.set_cursor(0, config.HEIGHT // 4)
-    gfx.print("PRESS")
-    gfx.set_cursor(0, config.HEIGHT // 2)
-    gfx.print("RESET")
-    gfx.display()
+    _prompt_screen(gfx, "PRESS", "RESET")
     print("  >>> press the RESET button (the board reboots)")
     board.clear_buttons()
     deadline = None if BUTTON_TIMEOUT is None else time.time() + BUTTON_TIMEOUT

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -103,18 +103,23 @@ def _gallery_text(gfx: Gfx) -> None:
     w, h = config.WIDTH, config.HEIGHT
     gfx.reset()
     gfx.fill_screen(0)
+    # top-left, base size
     gfx.set_text_color(255, 255, 255)
     gfx.set_text_size(1, 1)
     gfx.set_cursor(0, 0)
-    gfx.print('size 1x1 top-left')
+    gfx.print('top-left')
+    # middle, double size
     gfx.set_text_size(2, 2)
     gfx.set_text_color(255, 255, 0)
     gfx.set_cursor(0, h // 3)
     gfx.print('SIZE 2')
+    # bottom-right, measured with getTextBounds and right/bottom-aligned
     gfx.set_text_size(1, 1)
     gfx.set_text_color(0, 255, 255)
-    gfx.set_cursor(w // 2, h - 10)
-    gfx.print('bottom-right')
+    label = 'bottom-right'
+    tw, th = gfx.get_text_bounds(0, 0, label)
+    gfx.set_cursor(max(0, w - tw), max(0, h - th))
+    gfx.print(label)
     gfx.display()
 
 

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -159,22 +159,42 @@ def phase1_gallery(board: Board, results: Results) -> None:
         results.check(f'gallery:{name}', _ask(question))
 
 
-def phase1_buttons(board: Board, results: Results) -> None:
-    print('\n== Phase 1b: buttons (follow the prompts) ==')
-    for code, label in [('A', 'A (D0)'), ('B', 'B (D1)'), ('C', 'C (D2)')]:
-        input(f'Press and release button {label}, then Enter is not needed... ')
-        btns = board.wait_button(timeout=15)
-        results.check(
-            f'button:{code}', code in btns, f'got {sorted(btns) or "nothing"}'
-        )
+def _poll_for_button(board: Board, code: str, timeout: int = 15) -> set[str]:
+    """Poll `readButtons` until `code` is pressed (or timeout). Returns all
+    codes seen (for diagnostics when nothing matches)."""
+    seen: set[str] = set()
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            b = board.read_buttons()
+        except Exception:
+            b = set()
+        seen |= b
+        if code in b:
+            break
+        time.sleep(0.05)
+    return seen
 
-    print('Now press the RESET button (the board will reboot)...')
+
+def phase1_buttons(board: Board, results: Results) -> None:
+    # Read the gadget's buttons by polling — no terminal input here.
+    print('\n== Phase 1b: buttons — press the button ON THE GADGET ==')
+    board.clear_buttons()  # reset reboot counter so `R` isn't reported spuriously
+    for code, label in [('A', 'A (D0)'), ('B', 'B (D1)'), ('C', 'C (D2)')]:
+        print(f'  >>> press and hold button {label} for ~1s (up to 15s)...')
+        seen = _poll_for_button(board, code)
+        results.check(
+            f'button:{code}', code in seen, f'saw {sorted(seen) or "nothing"}'
+        )
+        time.sleep(1)  # give the user time to release before the next prompt
+
+    print('  >>> now press the RESET button (the board reboots)...')
     board.clear_buttons()
     deadline = time.time() + 20
     detected = False
     while time.time() < deadline:
         try:
-            if 'R' in board.read_buttons(flush=True):
+            if 'R' in board.read_buttons():
                 detected = True
                 break
         except Exception:

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -25,6 +25,7 @@ import time
 from typing import Callable
 
 from arduino_esp32_tft_terminal import config
+from arduino_esp32_tft_terminal.lib import READY
 from arduino_esp32_tft_terminal.lib.board import Board
 from arduino_esp32_tft_terminal.lib.channel import Channel
 from arduino_esp32_tft_terminal.lib.gfx import Gfx
@@ -212,10 +213,11 @@ _LOGO_REF = """\
 
 
 def phase0_boot(board: Board, results: Results) -> None:
-    # Reboot the board and check its power-on behaviour (logo + NeoPixel).
+    # Use the PHYSICAL reset button — NOT the `reboot` command, which would drop
+    # the board into USB-disk/bootloader mode. The channel layer reopens the TTY
+    # when the board comes back.
     _title("boot:logo")
-    print("  rebooting the board...")
-    board.reboot()
+    print("  >>> press the RESET button now (the board reboots)")
     print("  expected boot screen:")
     print(_LOGO_REF)
     results.check("boot:logo", _ask("does the board show that boot/logo screen?"))
@@ -224,7 +226,14 @@ def phase0_boot(board: Board, results: Results) -> None:
         "boot:neopixel",
         _ask("is the RGB (NeoPixel) LED pulsing and slowly cycling colour?"),
     )
-    board.configure()  # re-establish the configured state after the reboot
+    # Reconnect over the freshly re-enumerated TTY and restore the config state.
+    # Disable the READY callback so the reconnect can't trigger a `reboot`.
+    board.chan.set_callback(READY, None)
+    board.chan.open()  # channel retries until the TTY is back
+    board.gfx.set_rotation(config.SCREEN_ROTATION)
+    board.gfx.set_auto_display_off()
+    board.gfx.reset()
+    board.clear_buttons()
 
 
 # Seconds to wait for each interactive button press (None = wait forever).

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -201,6 +201,32 @@ def phase1_gallery(board: Board, results: Results) -> None:
         results.check(f"gallery:{name}", _ask(question))
 
 
+_LOGO_REF = """\
+  ┌─────────────────────┐
+  │ WEYLAND-YUTANI CORP │
+  │                     │
+  │         LOGO        │
+  │                     │
+  └─────────────────────┘
+"""
+
+
+def phase0_boot(board: Board, results: Results) -> None:
+    # Reboot the board and check its power-on behaviour (logo + NeoPixel).
+    _title("boot:logo")
+    print("  rebooting the board...")
+    board.reboot()
+    print("  expected boot screen:")
+    print(_LOGO_REF)
+    results.check("boot:logo", _ask("does the board show that boot/logo screen?"))
+    _title("boot:neopixel")
+    results.check(
+        "boot:neopixel",
+        _ask("is the RGB (NeoPixel) LED pulsing and slowly cycling colour?"),
+    )
+    board.configure()  # re-establish the configured state after the reboot
+
+
 # Seconds to wait for each interactive button press (None = wait forever).
 BUTTON_TIMEOUT: float | None = 60
 
@@ -373,6 +399,7 @@ def main() -> None:
     board = connect()
     results = Results()
     if not unattended_only:
+        phase0_boot(board, results)
         phase1_gallery(board, results)
         phase1_buttons(board, results)
     phase2_unattended(board, results)

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -159,34 +159,48 @@ def phase1_gallery(board: Board, results: Results) -> None:
         results.check(f'gallery:{name}', _ask(question))
 
 
-def _poll_for_button(board: Board, code: str, timeout: int = 15) -> set[str]:
-    """Poll `readButtons` until `code` is pressed (or timeout). Returns all
-    codes seen (for diagnostics when nothing matches)."""
+def _await_auto_button(board: Board, code: str, timeout: int = 15) -> set[str]:
+    """In auto-report mode the board appends button codes to every OK response.
+    Elicit responses (a cheap `display`) and accumulate codes until `code` is
+    seen (or timeout). Returns all codes seen (for diagnostics)."""
     seen: set[str] = set()
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            b = board.read_buttons()
+            board.gfx.display()  # its OK response carries the current buttons
+            seen |= board.auto_read_buttons()
         except Exception:
-            b = set()
-        seen |= b
-        if code in b:
+            pass
+        if code in seen:
             break
         time.sleep(0.05)
     return seen
 
 
 def phase1_buttons(board: Board, results: Results) -> None:
-    # Read the gadget's buttons by polling — no terminal input here.
+    # Buttons via auto-report mode (the path the apps use): once enabled, the
+    # board appends button codes to every OK response.
     print('\n== Phase 1b: buttons — press the button ON THE GADGET ==')
+    gfx = board.gfx
     board.clear_buttons()  # reset reboot counter so `R` isn't reported spuriously
-    for code, label in [('A', 'A (D0)'), ('B', 'B (D1)'), ('C', 'C (D2)')]:
-        print(f'  >>> press and hold button {label} for ~1s (up to 15s)...')
-        seen = _poll_for_button(board, code)
-        results.check(
-            f'button:{code}', code in seen, f'saw {sorted(seen) or "nothing"}'
-        )
-        time.sleep(1)  # give the user time to release before the next prompt
+    board.begin_auto_read_buttons()
+    try:
+        for code, label in [('A', 'A (D0)'), ('B', 'B (D1)'), ('C', 'C (D2)')]:
+            gfx.reset()
+            gfx.fill_screen(0)
+            gfx.set_text_color(255, 255, 255)
+            gfx.set_text_size(2, 2)
+            gfx.set_cursor(0, config.HEIGHT // 3)
+            gfx.print(f'PRESS {code}')
+            gfx.display()
+            print(f'  >>> press button {label} (up to 15s)...')
+            seen = _await_auto_button(board, code)
+            results.check(
+                f'button:{code}', code in seen, f'saw {sorted(seen) or "nothing"}'
+            )
+            time.sleep(0.5)  # let the user release before the next prompt
+    finally:
+        board.end_auto_read_buttons()
 
     print('  >>> now press the RESET button (the board reboots)...')
     board.clear_buttons()

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -76,6 +76,7 @@ def connect() -> Board:
 
 
 def _ask(prompt: str) -> bool:
+    prompt = prompt[:1].upper() + prompt[1:]
     return input(f"{prompt} [y/N] ").strip().lower().startswith("y")
 
 
@@ -233,7 +234,7 @@ def phase0_boot(board: Board, results: Results) -> None:
     # when the board comes back.
     _title("boot:logo")
     _prompt_screen(board.gfx, "PRESS", "RESET")
-    print("  >>> press the RESET button now (the board reboots)")
+    print(">>> press the RESET button now (the board reboots)")
     print("  expected boot screen:")
     print(_LOGO_REF)
     results.check("boot:logo", _ask("does the board show that boot/logo screen?"))
@@ -286,7 +287,7 @@ def phase1_buttons(board: Board, results: Results) -> None:
         for code, label in [("A", "A (D0)"), ("B", "B (D1)"), ("C", "C (D2)")]:
             _title(f"button:{code}")
             _prompt_screen(gfx, f"PRESS {code}")
-            print(f"  >>> press button {label}")
+            print(f">>> press button {label}")
             seen = _await_auto_button(board, code)
             results.check(
                 f"button:{code}", code in seen, f'saw {sorted(seen) or "nothing"}'
@@ -297,7 +298,7 @@ def phase1_buttons(board: Board, results: Results) -> None:
 
     _title("button:reset")
     _prompt_screen(gfx, "PRESS", "RESET")
-    print("  >>> press the RESET button (the board reboots)")
+    print(">>> press the RESET button (the board reboots)")
     board.clear_buttons()
     deadline = None if BUTTON_TIMEOUT is None else time.time() + BUTTON_TIMEOUT
     detected = False

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -124,53 +124,87 @@ def _gallery_text(gfx: Gfx) -> None:
 
 
 def _gallery_frame(gfx: Gfx) -> None:
+    w, h = config.WIDTH, config.HEIGHT
     gfx.reset()
     gfx.fill_screen(0)
-    gfx.set_fg_color(255, 255, 255)
-    # 1px border exactly at the screen edge
-    gfx.draw_rect(0, 0, config.WIDTH, config.HEIGHT, 1)
-    # crosshatch on round coordinates
+    # inset crosshatch (interior only — never touches the border)
     gfx.set_fg_color(64, 64, 64)
-    for x in range(0, config.WIDTH, 20):
-        gfx.draw_fast_vline(x, 0, config.HEIGHT, 1)
-    for y in range(0, config.HEIGHT, 20):
-        gfx.draw_fast_hline(0, y, config.WIDTH, 1)
+    for x in range(20, w - 1, 20):
+        gfx.draw_fast_vline(x, 1, h - 2, 1)
+    for y in range(20, h - 1, 20):
+        gfx.draw_fast_hline(1, y, w - 2, 1)
+    # 1px border as four explicit edge lines
+    gfx.set_fg_color(255, 255, 255)
+    gfx.draw_fast_hline(0, 0, w, 1)
+    gfx.draw_fast_hline(0, h - 1, w, 1)
+    gfx.draw_fast_vline(0, 0, h, 1)
+    gfx.draw_fast_vline(w - 1, 0, h, 1)
     gfx.display()
 
 
-GALLERY: list[tuple[str, Callable[[Gfx], None], str]] = [
+_SHAPES_REF = """\
+    ╲         □■     ○●
+     ╲
+               ·     │
+               ──────+─
+    ◣  ◢             │
+"""
+
+_TEXT_REF = """\
+  ┌────────────────────┐
+  │ top-left           │  small, white
+  │                    │
+  │ SIZE 2             │  large, yellow
+  │                    │
+  │        bottom-right│  small, cyan
+  └────────────────────┘
+"""
+
+GALLERY: list[tuple[str, Callable[[Gfx], None], str, str]] = [
     (
         'shapes',
         _gallery_shapes,
-        'lines, rects, circles, triangles, hline/vline, pixel — all present and correctly placed?',
+        'do the shapes match the reference (all present, placed alike)?',
+        _SHAPES_REF,
     ),
     (
         'text',
         _gallery_text,
-        'three text labels, right size/colour/position, no wrap artefacts?',
+        'do the labels match the reference (text, size, colour, position)?',
+        _TEXT_REF,
     ),
     (
         'frame',
         _gallery_frame,
-        'a 1px border touching all four edges + an even crosshatch grid?',
+        'a 1px border touching all four edges + an even interior crosshatch?',
+        '',
     ),
 ]
 
 
 def phase1_gallery(board: Board, results: Results) -> None:
     print('\n== Phase 1a: primitive gallery (glance check) ==')
-    for name, draw, question in GALLERY:
+    for name, draw, question, reference in GALLERY:
         draw(board.gfx)
+        if reference:
+            print('  expected layout:')
+            print(reference)
         results.check(f'gallery:{name}', _ask(question))
 
 
-def _await_auto_button(board: Board, code: str, timeout: int = 15) -> set[str]:
+# Seconds to wait for each interactive button press (None = wait forever).
+BUTTON_TIMEOUT: float | None = 60
+
+
+def _await_auto_button(
+    board: Board, code: str, timeout: float | None = BUTTON_TIMEOUT
+) -> set[str]:
     """In auto-report mode the board appends button codes to every OK response.
     Elicit responses (a cheap `display`) and accumulate codes until `code` is
-    seen (or timeout). Returns all codes seen (for diagnostics)."""
+    seen (or `timeout` elapses; None waits forever). Returns codes seen."""
     seen: set[str] = set()
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    deadline = None if timeout is None else time.time() + timeout
+    while deadline is None or time.time() < deadline:
         try:
             board.gfx.display()  # its OK response carries the current buttons
             seen |= board.auto_read_buttons()
@@ -198,7 +232,7 @@ def phase1_buttons(board: Board, results: Results) -> None:
             gfx.set_cursor(0, config.HEIGHT // 3)
             gfx.print(f'PRESS {code}')
             gfx.display()
-            print(f'  >>> press button {label} (up to 15s)...')
+            print(f'  >>> press button {label}')
             seen = _await_auto_button(board, code)
             results.check(
                 f'button:{code}', code in seen, f'saw {sorted(seen) or "nothing"}'
@@ -207,11 +241,22 @@ def phase1_buttons(board: Board, results: Results) -> None:
     finally:
         board.end_auto_read_buttons()
 
-    print('  >>> now press the RESET button (the board reboots)...')
+    # Show the RESET prompt on the TFT (replaces the last "PRESS X" screen).
+    # "PRESS RESET" doesn't fit on one line at this size, so stack it.
+    gfx.reset()
+    gfx.fill_screen(0)
+    gfx.set_text_color(255, 255, 255)
+    gfx.set_text_size(2, 2)
+    gfx.set_cursor(0, config.HEIGHT // 4)
+    gfx.print('PRESS')
+    gfx.set_cursor(0, config.HEIGHT // 2)
+    gfx.print('RESET')
+    gfx.display()
+    print('  >>> press the RESET button (the board reboots)')
     board.clear_buttons()
-    deadline = time.time() + 20
+    deadline = None if BUTTON_TIMEOUT is None else time.time() + BUTTON_TIMEOUT
     detected = False
-    while time.time() < deadline:
+    while deadline is None or time.time() < deadline:
         try:
             if 'R' in board.read_buttons():
                 detected = True
@@ -219,7 +264,7 @@ def phase1_buttons(board: Board, results: Results) -> None:
         except Exception:
             pass  # serial may drop across the reset; recovery re-opens
         time.sleep(0.2)
-    results.check('button:R (reset->reboot)', detected)
+    results.check('button:reset', detected, 'reset -> reboot reported as R')
 
 
 # ----------------------------------------------------------------------------
@@ -290,6 +335,25 @@ def phase2_unattended(board: Board, results: Results) -> None:
     results.check('soak:no-spurious-reboot', board.boots == boots_before)
 
 
+def _show_done(board: Board, ok: bool) -> None:
+    """Leave a clear end screen on the gadget (not the leftover soak frame)."""
+    gfx = board.gfx
+    gfx.reset()
+    gfx.fill_screen(0)
+    gfx.set_text_size(1, 1)
+    gfx.set_text_color(255, 255, 255)
+    gfx.set_cursor(0, config.HEIGHT // 4)
+    gfx.print('Self-test done')
+    gfx.set_text_size(2, 2)
+    if ok:
+        gfx.set_text_color(0, 255, 0)
+    else:
+        gfx.set_text_color(255, 0, 0)
+    gfx.set_cursor(0, config.HEIGHT // 2)
+    gfx.print('PASS' if ok else 'FAIL')
+    gfx.display()
+
+
 def main() -> None:
     unattended_only = '--unattended-only' in sys.argv
     board = connect()
@@ -299,6 +363,8 @@ def main() -> None:
         phase1_buttons(board, results)
     phase2_unattended(board, results)
     results.summary()
+    _show_done(board, results.ok)
+    print('\nAll tests complete.')
     sys.exit(0 if results.ok else 1)
 
 

--- a/client-py/src/arduino_esp32_tft_terminal/selftest.py
+++ b/client-py/src/arduino_esp32_tft_terminal/selftest.py
@@ -1,0 +1,267 @@
+"""On-board acceptance self-test (`make test-board`).
+
+Drives a connected gadget over USB to verify the firmware correctly implements
+the USB protocol primitives. It does NOT test the panel hardware or the
+Adafruit library (trusted SOUP) — only what this project owns.
+
+Two phases, interactive first so the user is needed only briefly at the start:
+
+  Phase 1 — interactive (attended):
+    1. a primitive gallery; the user confirms each screen by glance (y/n);
+    2. guided button presses, asserted at low level (A/B/C) and high level
+       (RESET -> reboot reported as the `R` event).
+
+  Phase 2 — unattended (walk away):
+    - every client primitive is sent and checked for a non-error response;
+    - queries (width/height/getTextBounds) are sanity-checked;
+    - a short soak cycles commands and asserts no comm errors / spurious reboots.
+
+Not in CI — needs the gadget on USB. Run: `make test-board`
+(`--unattended-only` skips Phase 1, e.g. for re-runs).
+"""
+
+import sys
+import time
+from typing import Callable
+
+from arduino_esp32_tft_terminal import config
+from arduino_esp32_tft_terminal.lib.board import Board
+from arduino_esp32_tft_terminal.lib.channel import Channel
+from arduino_esp32_tft_terminal.lib.gfx import Gfx
+
+
+class Results:
+    """Collects pass/fail checks and prints a summary."""
+
+    def __init__(self) -> None:
+        self.checks: list[tuple[str, bool, str]] = []
+
+    def check(self, name: str, ok: bool, detail: str = '') -> None:
+        self.checks.append((name, ok, detail))
+        mark = 'PASS' if ok else 'FAIL'
+        print(f'  [{mark}] {name}' + (f' — {detail}' if detail else ''))
+
+    @property
+    def ok(self) -> bool:
+        return all(ok for _, ok, _ in self.checks)
+
+    def summary(self) -> None:
+        passed = sum(1 for _, ok, _ in self.checks if ok)
+        total = len(self.checks)
+        print(f'\nself-test: {passed}/{total} checks passed.')
+        if not self.ok:
+            print('Failed:')
+            for name, ok, detail in self.checks:
+                if not ok:
+                    print(f'  - {name}' + (f' ({detail})' if detail else ''))
+
+
+def connect() -> Board:
+    """Open the serial port and configure the board (blocks until present)."""
+    print('Connecting to the board over USB...')
+    board = Board(Channel())
+    board.configure()
+    assert config.WIDTH and config.HEIGHT
+    print(f'Connected: {config.WIDTH}x{config.HEIGHT}.')
+    return board
+
+
+# ----------------------------------------------------------------------------
+# Phase 1 — interactive
+# ----------------------------------------------------------------------------
+
+
+def _ask(prompt: str) -> bool:
+    return input(f'{prompt} [y/N] ').strip().lower().startswith('y')
+
+
+def _gallery_shapes(gfx: Gfx) -> None:
+    # Coordinates derive from the queried resolution so the screen fits any
+    # board (the USB protocol is board-agnostic; only W/H and colour differ).
+    w, h = config.WIDTH, config.HEIGHT
+    r = max(4, h // 8)
+    gfx.reset()
+    gfx.fill_screen(0)
+    gfx.set_fg_color(255, 255, 255)
+    gfx.draw_line(0, 0, w // 3, h // 2, 1)
+    gfx.draw_rect(w // 3, 2, w // 6, h // 5, 1)
+    gfx.fill_rect(w // 2, 2, w // 6, h // 5, 1)
+    gfx.set_fg_color(255, 0, 0)
+    gfx.draw_circle(w * 3 // 4, h // 4, r, 1)
+    gfx.fill_circle(w - r - 2, h // 4, r, 1)
+    gfx.set_fg_color(0, 255, 0)
+    gfx.draw_triangle(2, h - 2, w // 6, h - 2, w // 12, h * 2 // 3, 1)
+    gfx.fill_triangle(w // 5, h - 2, w // 3, h - 2, w * 4 // 15, h * 2 // 3, 1)
+    gfx.set_fg_color(64, 128, 255)
+    gfx.draw_fast_hline(w // 2, h * 2 // 3, w // 3, 1)
+    gfx.draw_fast_vline(w * 3 // 4, h // 2, h // 3, 1)
+    gfx.draw_pixel(w // 2, h // 2, 1)
+    gfx.display()
+
+
+def _gallery_text(gfx: Gfx) -> None:
+    w, h = config.WIDTH, config.HEIGHT
+    gfx.reset()
+    gfx.fill_screen(0)
+    gfx.set_text_color(255, 255, 255)
+    gfx.set_text_size(1, 1)
+    gfx.set_cursor(0, 0)
+    gfx.print('size 1x1 top-left')
+    gfx.set_text_size(2, 2)
+    gfx.set_text_color(255, 255, 0)
+    gfx.set_cursor(0, h // 3)
+    gfx.print('SIZE 2')
+    gfx.set_text_size(1, 1)
+    gfx.set_text_color(0, 255, 255)
+    gfx.set_cursor(w // 2, h - 10)
+    gfx.print('bottom-right')
+    gfx.display()
+
+
+def _gallery_frame(gfx: Gfx) -> None:
+    gfx.reset()
+    gfx.fill_screen(0)
+    gfx.set_fg_color(255, 255, 255)
+    # 1px border exactly at the screen edge
+    gfx.draw_rect(0, 0, config.WIDTH, config.HEIGHT, 1)
+    # crosshatch on round coordinates
+    gfx.set_fg_color(64, 64, 64)
+    for x in range(0, config.WIDTH, 20):
+        gfx.draw_fast_vline(x, 0, config.HEIGHT, 1)
+    for y in range(0, config.HEIGHT, 20):
+        gfx.draw_fast_hline(0, y, config.WIDTH, 1)
+    gfx.display()
+
+
+GALLERY: list[tuple[str, Callable[[Gfx], None], str]] = [
+    (
+        'shapes',
+        _gallery_shapes,
+        'lines, rects, circles, triangles, hline/vline, pixel — all present and correctly placed?',
+    ),
+    (
+        'text',
+        _gallery_text,
+        'three text labels, right size/colour/position, no wrap artefacts?',
+    ),
+    (
+        'frame',
+        _gallery_frame,
+        'a 1px border touching all four edges + an even crosshatch grid?',
+    ),
+]
+
+
+def phase1_gallery(board: Board, results: Results) -> None:
+    print('\n== Phase 1a: primitive gallery (glance check) ==')
+    for name, draw, question in GALLERY:
+        draw(board.gfx)
+        results.check(f'gallery:{name}', _ask(question))
+
+
+def phase1_buttons(board: Board, results: Results) -> None:
+    print('\n== Phase 1b: buttons (follow the prompts) ==')
+    for code, label in [('A', 'A (D0)'), ('B', 'B (D1)'), ('C', 'C (D2)')]:
+        input(f'Press and release button {label}, then Enter is not needed... ')
+        btns = board.wait_button(timeout=15)
+        results.check(
+            f'button:{code}', code in btns, f'got {sorted(btns) or "nothing"}'
+        )
+
+    print('Now press the RESET button (the board will reboot)...')
+    board.clear_buttons()
+    deadline = time.time() + 20
+    detected = False
+    while time.time() < deadline:
+        try:
+            if 'R' in board.read_buttons(flush=True):
+                detected = True
+                break
+        except Exception:
+            pass  # serial may drop across the reset; recovery re-opens
+        time.sleep(0.2)
+    results.check('button:R (reset->reboot)', detected)
+
+
+# ----------------------------------------------------------------------------
+# Phase 2 — unattended
+# ----------------------------------------------------------------------------
+
+PRIMITIVES: list[tuple[str, Callable[[Gfx], None]]] = [
+    ('reset', lambda g: g.reset()),
+    ('fillScreen', lambda g: g.fill_screen(0)),
+    ('setFgColor', lambda g: g.set_fg_color(255, 0, 0)),
+    ('setBgColor', lambda g: g.set_bg_color(0, 0, 32)),
+    ('drawPixel', lambda g: g.draw_pixel(5, 5, 1)),
+    ('drawLine', lambda g: g.draw_line(0, 0, 50, 30, 1)),
+    ('drawRect', lambda g: g.draw_rect(2, 2, 40, 20, 1)),
+    ('fillRect', lambda g: g.fill_rect(2, 2, 40, 20, 1)),
+    ('drawCircle', lambda g: g.draw_circle(30, 30, 15, 1)),
+    ('fillCircle', lambda g: g.fill_circle(30, 30, 15, 1)),
+    ('drawTriangle', lambda g: g.draw_triangle(0, 0, 20, 0, 10, 20, 1)),
+    ('fillTriangle', lambda g: g.fill_triangle(0, 0, 20, 0, 10, 20, 1)),
+    ('drawFastHLine', lambda g: g.draw_fast_hline(0, 10, 50, 1)),
+    ('drawFastVLine', lambda g: g.draw_fast_vline(10, 0, 40, 1)),
+    ('setTextSize', lambda g: g.set_text_size(1, 1)),
+    ('setTextColor', lambda g: g.set_text_color(255, 255, 255)),
+    ('setCursor', lambda g: g.set_cursor(0, 0)),
+    ('setTextWrapOn', lambda g: g.set_text_wrap_on()),
+    ('setTextWrapOff', lambda g: g.set_text_wrap_off()),
+    ('home', lambda g: g.home()),
+    ('print', lambda g: g.print('selftest')),
+    ('clear', lambda g: g.clear()),
+    ('setRotation', lambda g: g.set_rotation(config.SCREEN_ROTATION)),
+    ('display', lambda g: g.display()),
+]
+
+
+def phase2_unattended(board: Board, results: Results) -> None:
+    print('\n== Phase 2: unattended protocol conformance ==')
+    gfx = board.gfx
+
+    # Every client primitive must dispatch without an ERROR response.
+    for name, call in PRIMITIVES:
+        try:
+            call(gfx)
+            results.check(f'cmd:{name}', True)
+        except Exception as e:
+            results.check(f'cmd:{name}', False, str(e))
+
+    # Queries return sane values.
+    results.check('query:width', gfx.get_width() > 0)
+    results.check('query:height', gfx.get_height() > 0)
+    w, h = gfx.get_text_bounds(0, 0, 'Hi')
+    results.check('query:getTextBounds', w > 0 and h > 0, f'{w}x{h}')
+
+    # Short soak: cycle drawing, assert no comm errors / spurious reboots.
+    print('  soak: drawing for 5s...')
+    boots_before = board.boots
+    errors = 0
+    end = time.time() + 5
+    i = 0
+    while time.time() < end:
+        try:
+            gfx.fill_screen(0)
+            gfx.draw_circle(i % config.WIDTH, i % config.HEIGHT, 10, 1)
+            gfx.display()
+            i += 1
+        except Exception:
+            errors += 1
+    results.check('soak:no-comm-errors', errors == 0, f'{errors} errors')
+    results.check('soak:no-spurious-reboot', board.boots == boots_before)
+
+
+def main() -> None:
+    unattended_only = '--unattended-only' in sys.argv
+    board = connect()
+    results = Results()
+    if not unattended_only:
+        phase1_gallery(board, results)
+        phase1_buttons(board, results)
+    phase2_unattended(board, results)
+    results.summary()
+    sys.exit(0 if results.ok else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/devlog/0026-selftest.md
+++ b/devlog/0026-selftest.md
@@ -1,0 +1,80 @@
+# 0026 — On-board self-test (primitive gallery + buttons)
+
+- GH issue: #26
+- Branch: impl/0026-selftest
+- Opened: 2026-06-27
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+An on-board acceptance suite (`make test-board`) verifying the firmware implements the USB protocol primitives, with no firmware change. Interactive parts front-loaded so the user is needed only briefly. Design settled across the 0024 study discussion.
+
+### Acceptance criteria
+
+1. Phase 1 interactive (attended): primitive gallery (glance y/n) + guided button presses (A/B/C + reset→`R`).
+2. Phase 2 unattended: every client primitive sent and checked for a non-error response; query sanity; short soak (no comm errors / spurious reboots).
+3. `make test-board` (opt-in, needs board; not CI). `make test` stays host-only.
+4. Board-model-agnostic: coordinates derive from queried `WIDTH`/`HEIGHT` (only resolution/colour differ across boards; the obsolete FeatherWing is the precedent).
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+`selftest.py` module: `connect()` (Channel+Board+configure), Phase 1 (`phase1_gallery`, `phase1_buttons`), Phase 2 (`phase2_unattended`), `main()` orchestrating interactive-then-unattended with a pass/fail `Results` summary and exit code. Makefile `test-board` target.
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 What was built
+
+- `src/arduino_esp32_tft_terminal/selftest.py` — the two-phase driver (24 primitive conformance checks, 3 gallery screens, A/B/C + reset button checks, 5 s soak).
+- `Makefile` — `test-board` target; `test` relabelled "host unit tests (no board)".
+- Gallery coordinates derive from `config.WIDTH`/`HEIGHT` → board-agnostic.
+
+### 3.2 Verification done (agent, off-board)
+
+- ruff clean; host pytest suite still 24/24.
+- `FakeChannel` sanity run: all 3 gallery screens draw, all 24 primitives dispatch (no wrong method names), queries return values. Confirms the command set + structure.
+
+### 3.3 Verification NOT done (needs the gadget — user)
+
+- Phase 1 visual glance (rendering correctness) and the physical A/B/C/reset prompts — by definition need the board and a human.
+- The reset→reboot→`R` detection across a serial drop is hardware-timing-dependent and may need tuning after a real run.
+
+### 3.4 Retrospective
+
+| #   | Point                                                        | Agent | User     |
+| --- | ------------------------------------------------------------ | ----- | -------- |
+| 1   | "board-dependent" conflated "needs hardware" with "board-specific" | not well | surprise |
+| 2   | Gallery made resolution-driven once the protocol-agnostic point landed | well |    |
+| 3   | Off-board sanity (FakeChannel) caught method-name risk pre-hardware | well |     |
+
+### 3.5 Verdict
+
+Accept pending the user's on-board run: structurally verified off-board; the interactive/hardware behaviour is theirs to confirm (and tune the reset detection if needed).
+
+## Governance trace
+
+| Source                       | Clause                  | Action  | Note                                              |
+| ---------------------------- | ----------------------- | ------- | ------------------------------------------------- |
+| CLAUDE.md (Proportionality)  | proportionality         | applied | human-in-the-loop, no FW change, no shadow buffer |
+| CLAUDE.md (Fact/inference)   | mark unknowns           | applied | flagged the hardware-only verification gap        |
+| devlog 0024                  | study outcome           | applied | interactive-first on-board suite as designed      |
+
+## Resource consumption
+
+| Phase     | Tokens (approx) | Wall time |
+| --------- | --------------- | --------- |
+| Implement | ~40k            | ~35 min   |
+
+| Counter       | Value |
+| ------------- | ----- |
+| Files changed | 3 (selftest.py, Makefile, devlog) |


### PR DESCRIPTION
On-board acceptance suite verifying the firmware implements the USB protocol primitives — **no firmware change**. Design settled in the #24 study discussion.

## `make test-board` (opt-in, needs the gadget on USB; not in CI)
- **Phase 1 — interactive (attended, front-loaded):** primitive gallery (glance `y/n` per screen) + guided **A/B/C** presses and **reset**→reboot→`R`.
- **Phase 2 — unattended (walk away):** every client primitive → assert non-error response; `width`/`height`/`getTextBounds` sanity; 5 s soak asserting no comm errors / spurious reboots.
- `make test` is relabelled host-only; `test-board` is separate.

Board-model-agnostic: gallery coordinates derive from queried `WIDTH`/`HEIGHT` (the protocol is uniform across boards — only resolution/colour differ).

## Verified off-board (me)
ruff clean; host suite still 24/24; `FakeChannel` sanity run — all 3 gallery screens draw and all 24 primitives dispatch (caught nothing wrong, but proves no bad method names), queries return values.

## Needs you (on the board)
The interactive glance + physical buttons, and the **reset→`R`** detection across the serial drop (hardware-timing-dependent — may need a tweak after a real run). Run `make test-board` and tell me what breaks.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)