### PR TITLE
[impl] F — CI (GitHub Actions running make check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: make check (ruff lint + pytest)
+        working-directory: client-py
+        run: make check

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Arduino ESP32 TFT Terminal
 
+[![CI](https://github.com/pbauermeister/arduino-esp32-tft-terminal/actions/workflows/ci.yml/badge.svg)](https://github.com/pbauermeister/arduino-esp32-tft-terminal/actions/workflows/ci.yml)
 [![PyPI version](https://img.shields.io/pypi/v/arduino-esp32-tft-terminal)](https://pypi.org/project/arduino-esp32-tft-terminal/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)

--- a/devlog/0028-ci.md
+++ b/devlog/0028-ci.md
@@ -1,0 +1,72 @@
+# 0028 — CI (GitHub Actions running make check)
+
+- GH issue: #28
+- Branch: impl/0028-ci
+- Opened: 2026-06-27
+- Closed: 2026-06-27
+
+Fast-path task (mechanical). Scope from `TODO.md` item F.
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+Add CI that guards lint + the host test suite on every push/PR to `main`.
+
+### Acceptance criteria
+
+1. `.github/workflows/ci.yml`: on push/PR to `main`, install uv and run `make check` in `client-py/`.
+2. Light Python matrix (3.11–3.13; floor is `claude-busy-monitor`'s 3.11).
+3. CI badge in the top README.
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+1. Workflow: `actions/checkout` + `astral-sh/setup-uv` (with `python-version` per matrix) + `make check` (working-directory `client-py`).
+2. Add the CI badge.
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 Notes
+
+- `make check` = `lint` (ruff over `src tests`) + `test` (pytest). The on-board `make test-board` stays manual (needs hardware) — not in CI.
+- Workflow correctness is validated by this PR's own CI run; if `setup-uv@v5` or the matrix needs adjusting, the run shows it.
+
+### 3.2 Verification
+
+- Validated by the PR's CI run (the workflow runs on the pull request).
+
+### 3.3 Retrospective
+
+| #   | Point                                          | Agent | User |
+| --- | ---------------------------------------------- | ----- | ---- |
+| 1   | CI runs the same `make check` devs run locally | well  |      |
+
+### 3.4 Verdict
+
+Accept once the PR's CI run is green.
+
+## Governance trace
+
+| Source                  | Clause          | Action  | Note                              |
+| ----------------------- | --------------- | ------- | --------------------------------- |
+| CLAUDE.md (Preferences) | established tools | applied | cbm-style uv + make check in CI   |
+
+## Resource consumption
+
+| Phase | Tokens (approx) | Wall time |
+| ----- | --------------- | --------- |
+| Total | ~6k             | ~6 min    |
+
+| Counter       | Value |
+| ------------- | ----- |
+| Files changed | 3 (ci.yml, README, devlog) |


### PR DESCRIPTION
TODO item F. CI guarding lint + the host test suite.

- `.github/workflows/ci.yml`: on push/PR to `main`, `astral-sh/setup-uv` + `make check` (ruff + pytest) in `client-py/`, Python matrix 3.11–3.13.
- CI badge added to the README.
- The on-board `make test-board` stays manual (needs hardware).

The workflow validates itself via this PR's own CI run — watch the check below; if `setup-uv@v5` or the matrix needs a tweak, it'll show and I'll fix.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)