### PR TITLE
[impl] publish-quality: gate on green GitHub CI for HEAD

### DIFF
--- a/client-py/Makefile
+++ b/client-py/Makefile
@@ -129,11 +129,29 @@ cycle: ## from scratch: uninstall clean lint test install verify (1)
 ################################################################################
 ## Publish to PyPI:: ##
 
+.PHONY: ci-green
+ci-green: ## assert GitHub CI for HEAD has finished and passed (gh) (3)
+	@SHA=$$(git rev-parse HEAD); \
+	echo "ci-green: GitHub CI for HEAD $$SHA"; \
+	RUNS=$$(gh run list --limit 40 --json databaseId,headSha \
+		--jq "[.[] | select(.headSha==\"$$SHA\")] | .[].databaseId"); \
+	if [ -z "$$RUNS" ]; then \
+		echo "ci-green: no CI run for HEAD — push the commit and let CI start" >&2; \
+		exit 1; \
+	fi; \
+	for r in $$RUNS; do \
+		echo "ci-green: watching run $$r..."; \
+		gh run watch "$$r" --exit-status \
+			|| { echo "ci-green: CI run $$r did not pass" >&2; exit 1; }; \
+	done; \
+	echo "ci-green: all CI runs for HEAD passed."
+
 .PHONY: publish-quality
-publish-quality: ## pre-publish gate: lint test reinstall build (1)
-	@echo "About to run lint + tests + uninstall/install cycle + build. Does NOT upload."
+publish-quality: ## pre-publish gate: ci-green lint test reinstall build (1)
+	@echo "About to verify CI + run lint/tests/install-cycle/build. Does NOT upload."
 	@echo "Ctrl-C within 2 seconds to abort."
 	@sleep 2
+	$(MAKE) ci-green
 	$(MAKE) lint
 	$(MAKE) test
 	-$(MAKE) uninstall
@@ -174,3 +192,4 @@ clean: ## remove venv, build artefacts, caches
 ## - (1) modifies the user account (~/.local/bin, uv tools).
 ## - (2) prerequisite — store the PyPI token in keyring once:
 ##       keyring set https://upload.pypi.org/legacy/ __token__
+## - (3) needs the `gh` CLI authenticated; HEAD must be pushed so CI has run.

--- a/client-py/Makefile
+++ b/client-py/Makefile
@@ -162,8 +162,10 @@ publish-quality: ## pre-publish gate: ci-green lint test reinstall build (1)
 	$(MAKE) build
 	@echo "publish-quality: all gates green; dist/ ready. Run 'make publish' to upload."
 
+# `publish` is intentionally ungated: `publish-quality` (which runs ci-green) is
+# the gate. Keeping `publish` raw preserves an emergency short-circuit.
 .PHONY: publish
-publish: ## upload to PyPI (raw; use publish-quality first) (2)
+publish: ## upload to PyPI (raw, ungated; use publish-quality) (2)
 	export UV_KEYRING_PROVIDER=subprocess; \
 	export UV_PUBLISH_USERNAME=__token__; \
 	uv publish

--- a/devlog/0030-publish-ci-gate.md
+++ b/devlog/0030-publish-ci-gate.md
@@ -1,0 +1,72 @@
+# 0030 — publish-quality gates on green GitHub CI
+
+- GH issue: #30
+- Branch: impl/0030-publish-ci-gate
+- Opened: 2026-06-27
+- Closed: 2026-06-27
+
+Fast-path task (mechanical). Scope from issue #30 / user request.
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+`make publish-quality` must confirm GitHub CI for HEAD has finished and passed before a release — never publish a commit CI hasn't blessed. Pattern from pikett-ai-mvp `release-manage.py` (`gh ... checks --watch`).
+
+### Acceptance criteria
+
+1. New low-level `ci-green` target: find the CI run(s) for HEAD and wait, failing if any didn't succeed.
+2. `publish-quality` runs `ci-green` first.
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+`ci-green`: `gh run list` filtered by `headSha` → `gh run watch <id> --exit-status` per run (waits + fails if not successful); error if no run exists (HEAD not pushed). Compose into `publish-quality`.
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 Notes
+
+- `gh run watch --exit-status` returns immediately for a completed run, or blocks until completion — covers both "CI still running" and "CI done".
+- Requires `gh` authenticated and HEAD pushed (footnote (3) in the Makefile).
+
+### 3.2 Verification
+
+- `make help` lists `ci-green`; `publish-quality` doc updated.
+- `make ci-green` on a commit with a green run → finds it, watches, "all CI runs for HEAD passed", exit 0 (validated against the merged-F CI run).
+- No-run guard: empty run list → exit 1 with a push-first message.
+
+### 3.3 Retrospective
+
+| #   | Point                                                | Agent | User |
+| --- | ---------------------------------------------------- | ----- | ---- |
+| 1   | Reused the pikett `gh ... --watch` release pattern   | well  |      |
+
+### 3.4 Verdict
+
+Accept.
+
+## Governance trace
+
+| Source                  | Clause           | Action  | Note                                |
+| ----------------------- | ---------------- | ------- | ----------------------------------- |
+| CLAUDE.md (Preferences) | established methods | applied | reused pikett release-gate pattern  |
+
+## Resource consumption
+
+| Phase | Tokens (approx) | Wall time |
+| ----- | --------------- | --------- |
+| Total | ~8k             | ~10 min   |
+
+| Counter       | Value |
+| ------------- | ----- |
+| Files changed | 2 (Makefile, devlog) |


### PR DESCRIPTION
`make publish-quality` now refuses to proceed unless GitHub CI for the current HEAD has finished and passed.

- New low-level **`ci-green`**: `gh run list` (by `headSha`) → `gh run watch <id> --exit-status` per run — waits for in-flight CI, fails if any run didn't succeed, errors if HEAD isn't pushed.
- `publish-quality` runs `ci-green` first (before lint/test/install/build).
- Pattern borrowed from pikett-ai-mvp `release-manage.py`.

Validated: `make ci-green` against a commit with a green run → "all CI runs for HEAD passed", exit 0; `make help` lists it.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)