### PR TITLE
[impl] Firmware Makefile targets + .clang-format

### DIFF
--- a/devlog/0032-firmware-targets.md
+++ b/devlog/0032-firmware-targets.md
@@ -1,0 +1,75 @@
+# 0032 — Firmware Makefile targets + .clang-format
+
+- GH issue: #32
+- Branch: impl/0032-firmware-targets
+- Opened: 2026-06-27
+- Closed: 2026-06-27
+
+Fast-path task (mechanical). Scope from `TODO.md` (split out of G).
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+Give the firmware (`server-esp32s3-rtft/`) the same `make` ergonomics as the client: a committed `.clang-format` and `arduino-cli` build/upload targets.
+
+### Acceptance criteria
+
+1. `.clang-format` matching the documented style (Google, IndentWidth 4).
+2. `server-esp32s3-rtft/Makefile`: `help`, `format`, `format-check`, `firmware-build`, `firmware-upload`, `require`.
+3. Targets use the correct FQBN/options (from `.vscode/arduino.json`).
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+`.clang-format` (Google/indent-4); Makefile with clang-format format/check + `arduino-cli compile`/`upload` (FQBN `esp32:esp32:adafruit_feather_esp32s3_reversetft` + key board options) + a `require` (core install).
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 Verification
+
+- `make help` lists all targets.
+- `make format-check` runs clang-format and reports violations (the tool works).
+- `make firmware-build` invokes `arduino-cli compile -b <fqbn:opts> .` correctly (reaches the compiler).
+
+### 3.2 Two findings (NOT fixed here — flagged)
+
+1. **Firmware isn't clang-format-clean** (~2730 lines would change). The `.clang-format` + `format` target are committed, but the existing sources were never strictly formatted. Not reformatted here: it's a large diff with no automated behaviour check, and reformatting working firmware deserves a separate, on-board-reverified step (`make format`, then a hardware smoke).
+2. **Firmware does not compile on esp32 core 3.3.0** — `command.cpp`'s `case hash("…"):` labels are `unsigned int` values above `INT_MAX` (e.g. 4071076125); the newer core's `-Werror=narrowing` rejects them. The current VS Code build must use an older core / laxer flags. The fix is small (make the hash/switch consistently `unsigned`), but it's a firmware **code** change, out of this task's scope and unverifiable without the board.
+
+### 3.3 Retrospective
+
+| #   | Point                                                          | Agent | User     |
+| --- | -------------------------------------------------------------- | ----- | -------- |
+| 1   | `firmware-build` immediately surfaced a real core-compat bug   | well  |          |
+| 2   | Did not reformat 2730 lines blind / did not fix firmware here  | well  |          |
+
+### 3.4 Verdict
+
+Accept (targets correct and verified to run). The two findings are follow-up candidates, not blockers.
+
+## Governance trace
+
+| Source                  | Clause          | Action  | Note                                         |
+| ----------------------- | --------------- | ------- | -------------------------------------------- |
+| CLAUDE.md (Proportionality) | proportionality | applied | tooling only; no blind reformat / firmware fix |
+| CLAUDE.md (Fact/inference)  | mark findings   | applied | narrowing + non-conformance flagged, not hidden |
+
+## Resource consumption
+
+| Phase | Tokens (approx) | Wall time |
+| ----- | --------------- | --------- |
+| Total | ~14k            | ~15 min   |
+
+| Counter       | Value |
+| ------------- | ----- |
+| Files changed | 3 (.clang-format, Makefile, devlog) |

--- a/devlog/0032-firmware-targets.md
+++ b/devlog/0032-firmware-targets.md
@@ -20,6 +20,8 @@ Give the firmware (`server-esp32s3-rtft/`) the same `make` ergonomics as the cli
 1. `.clang-format` matching the documented style (Google, IndentWidth 4).
 2. `server-esp32s3-rtft/Makefile`: `help`, `format`, `format-check`, `firmware-build`, `firmware-upload`, `require`.
 3. Targets use the correct FQBN/options (from `.vscode/arduino.json`).
+4. `require` bootstraps the whole toolchain (installs `arduino-cli` itself, not just the core).
+5. `firmware-upload` is proven against real hardware, not just present.
 
 ## 2. Execution plan
 
@@ -40,6 +42,8 @@ Give the firmware (`server-esp32s3-rtft/`) the same `make` ergonomics as the cli
 - `make help` lists all targets.
 - `make format-check` runs clang-format and reports violations (the tool works).
 - `make firmware-build` invokes `arduino-cli compile -b <fqbn:opts> .` correctly (reaches the compiler).
+- `require` now installs `arduino-cli` (official script → `~/.local/bin`) if absent, then the esp32 core.
+- **`firmware-upload` tested on real hardware** (needed the #35 build fix, merged in): build → flash → `-t` verify (`Hash of data verified`, hard reset, exit 0). Post-flash the board answers the protocol: `width → 240`, `height → 135`, `display → OK`.
 
 ### 3.2 Two findings (NOT fixed here — flagged)
 

--- a/server-esp32s3-rtft/.clang-format
+++ b/server-esp32s3-rtft/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+IndentWidth: 4

--- a/server-esp32s3-rtft/Makefile
+++ b/server-esp32s3-rtft/Makefile
@@ -30,11 +30,20 @@ firmware-build: ## compile the sketch (arduino-cli)
 	arduino-cli compile -b "$(FQBN):$(OPTS)" .
 
 .PHONY: firmware-upload
-firmware-upload: ## upload to the board over USB (set PORT=...)
-	arduino-cli upload -b "$(FQBN):$(OPTS)" -p "$(PORT)" .
+firmware-upload: firmware-build ## build + flash the board + verify (set PORT=...)
+	arduino-cli upload -b "$(FQBN):$(OPTS)" -p "$(PORT)" -t .
+
+ARDUINO_CLI_BINDIR ?= $(HOME)/.local/bin
 
 .PHONY: require
-require: ## install the esp32 core for arduino-cli
+require: ## install the toolchain (arduino-cli + esp32 core)
+	@command -v arduino-cli >/dev/null || { \
+		echo "installing arduino-cli into $(ARDUINO_CLI_BINDIR) ..."; \
+		mkdir -p "$(ARDUINO_CLI_BINDIR)"; \
+		curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh \
+			| BINDIR="$(ARDUINO_CLI_BINDIR)" sh; \
+		echo "note: ensure $(ARDUINO_CLI_BINDIR) is on your PATH"; \
+	}
 	arduino-cli config add board_manager.additional_urls \
 		https://espressif.github.io/arduino-esp32/package_esp32_index.json || true
 	arduino-cli core update-index

--- a/server-esp32s3-rtft/Makefile
+++ b/server-esp32s3-rtft/Makefile
@@ -1,0 +1,41 @@
+# Firmware build / format helpers for the ESP32-S3 board.
+# Run from this directory. Needs `arduino-cli` (+ the esp32 core) and
+# `clang-format`. Board settings mirror .vscode/arduino.json.
+
+SHELL := /bin/bash
+
+FQBN := esp32:esp32:adafruit_feather_esp32s3_reversetft
+# Key board options (the full set lives in .vscode/arduino.json).
+OPTS := USBMode=default,CDCOnBoot=cdc,PSRAM=enabled,PartitionScheme=tinyuf2,FlashSize=4M
+PORT ?= /dev/ttyACM0
+SRC  := $(wildcard *.ino *.cpp *.h)
+
+.PHONY: help
+help: ## print this help
+	@echo "usage: make COMMAND   (PORT=$(PORT) for upload)"
+	@echo
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile \
+	| awk 'BEGIN {FS = ":.*?## "}; {printf "  %-16s %s\n", $$1, $$2}'
+
+.PHONY: format
+format: ## clang-format the sources in place
+	clang-format -i $(SRC)
+
+.PHONY: format-check
+format-check: ## check formatting (read-only)
+	clang-format --dry-run --Werror $(SRC)
+
+.PHONY: firmware-build
+firmware-build: ## compile the sketch (arduino-cli)
+	arduino-cli compile -b "$(FQBN):$(OPTS)" .
+
+.PHONY: firmware-upload
+firmware-upload: ## upload to the board over USB (set PORT=...)
+	arduino-cli upload -b "$(FQBN):$(OPTS)" -p "$(PORT)" .
+
+.PHONY: require
+require: ## install the esp32 core for arduino-cli
+	arduino-cli config add board_manager.additional_urls \
+		https://espressif.github.io/arduino-esp32/package_esp32_index.json || true
+	arduino-cli core update-index
+	arduino-cli core install esp32:esp32


### PR DESCRIPTION
Gives the firmware the same `make` ergonomics as the client.

- `server-esp32s3-rtft/.clang-format` — Google, IndentWidth 4 (the documented VS Code style).
- `server-esp32s3-rtft/Makefile` — `help`, `format`, `format-check`, `firmware-build`, `firmware-upload`, `require`; FQBN + board options from `.vscode/arduino.json`.
- Verified: `make help` lists targets, `format-check` runs, `firmware-build` invokes `arduino-cli compile` correctly.

## Two findings flagged (not fixed here)
1. **Firmware isn't clang-format-clean** (~2730 lines). `.clang-format` + `format` target are in; reformatting the backlog is left as a separate, on-board-reverified step (`make format` then a hardware smoke).
2. **Firmware won't compile on esp32 core 3.3.0** — `command.cpp` `case hash("…")` labels exceed `INT_MAX`; the newer core's `-Werror=narrowing` rejects them. Small firmware fix (make the hash/switch `unsigned`), but a code change out of scope here.

Want either follow-up? (CI is unaffected — it only runs the client `make check`.)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)