### PR TITLE
[impl] Firmware: CI compile gate + require installs libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,21 @@ jobs:
       - name: make check (ruff lint + pytest)
         working-directory: client-py
         run: make check
+
+  firmware-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache arduino-cli core + libraries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.arduino15
+            ~/Arduino
+          key: arduino-${{ runner.os }}-esp32
+      - name: Install toolchain + compile firmware
+        working-directory: server-esp32s3-rtft
+        run: |
+          make require
+          export PATH="$HOME/.local/bin:$PATH"
+          make firmware-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           path: |
             ~/.arduino15
             ~/Arduino
-          key: arduino-${{ runner.os }}-esp32
+          key: arduino-${{ runner.os }}-esp32-3.3.0
       - name: Install toolchain + compile firmware
         working-directory: server-esp32s3-rtft
         run: |

--- a/devlog/0042-firmware-ci.md
+++ b/devlog/0042-firmware-ci.md
@@ -1,0 +1,63 @@
+# 0042 — Firmware: CI compile gate + require installs libraries
+
+- GH issue: #42
+- Branch: impl/0042-firmware-ci
+- Opened: 2026-06-27
+- Closed: 2026-06-27
+
+Fast-path task.
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+A CI job must verify the firmware compiles (would have caught the esp32-core narrowing regression, #35). For reproducibility, `make require` must install the firmware's libraries too.
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+1. `require`: one shell block, PATH-robust (works right after a fresh `arduino-cli` install); add `arduino-cli lib install` for Adafruit GFX, ST7735/ST7789, NeoPixel, TestBed, Button (BusIO + SdFat pulled as deps).
+2. `ci.yml`: a `firmware-build` job — cache `~/.arduino15` + `~/Arduino`, then `make require` + `make firmware-build`.
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 Verification
+
+- `make -n require` expands cleanly; `make help` shows the updated doc.
+- `ci.yml` is valid YAML (`jobs: check, firmware-build`).
+- All five library names resolve in the arduino-cli registry (checked locally).
+- The job itself is validated by this PR's own CI run (first run populates the cache).
+
+### 3.2 Notes
+
+- `require` is one shell block so the `PATH` export reaches the `arduino-cli` calls whether it was just installed or pre-existing.
+- The core install pins to whatever `esp32:esp32` is current; if a future core breaks the build, this job is exactly what flags it.
+
+### 3.3 Verdict
+
+Accept once the PR's CI run is green.
+
+## Governance trace
+
+| Source                  | Clause          | Action  | Note                                       |
+| ----------------------- | --------------- | ------- | ------------------------------------------ |
+| CLAUDE.md (reproducibility) | one setup path | applied | CI and dev share `make require` for libs   |
+
+## Resource consumption
+
+| Phase | Tokens (approx) | Wall time |
+| ----- | --------------- | --------- |
+| Total | ~9k             | ~12 min   |
+
+| Counter       | Value |
+| ------------- | ----- |
+| Files changed | 3 (Makefile, ci.yml, devlog) |

--- a/devlog/0042-firmware-ci.md
+++ b/devlog/0042-firmware-ci.md
@@ -40,7 +40,7 @@ A CI job must verify the firmware compiles (would have caught the esp32-core nar
 ### 3.2 Notes
 
 - `require` is one shell block so the `PATH` export reaches the `arduino-cli` calls whether it was just installed or pre-existing.
-- The core install pins to whatever `esp32:esp32` is current; if a future core breaks the build, this job is exactly what flags it.
+- **DRAM finding (CI surfaced it immediately):** the first CI run pulled core `3.3.10` (latest 3.3.x) and the link **failed** — `dram0_0_seg overflowed by 4224 bytes`. The firmware is near the static-RAM ceiling (84 % on 3.3.0), and 3.3.10 tips it over. Fix: **pin `esp32:esp32@3.3.0`** (the core the board is validated on) in `require` + the cache key, so dev/CI/board build the same. Reducing the firmware's DRAM headroom is a separate concern, parked.
 
 ### 3.3 Verdict
 

--- a/server-esp32s3-rtft/Makefile
+++ b/server-esp32s3-rtft/Makefile
@@ -42,18 +42,26 @@ help: ## print this help
 ## Setup:: ##
 
 .PHONY: require
-require: ## install the toolchain (arduino-cli + esp32 core)
-	@command -v arduino-cli >/dev/null || { \
+require: ## install the toolchain (arduino-cli + core + libs)
+	@set -e; \
+	if ! command -v arduino-cli >/dev/null; then \
 		echo "installing arduino-cli into $(ARDUINO_CLI_BINDIR) ..."; \
 		mkdir -p "$(ARDUINO_CLI_BINDIR)"; \
 		curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh \
 			| BINDIR="$(ARDUINO_CLI_BINDIR)" sh; \
 		echo "note: ensure $(ARDUINO_CLI_BINDIR) is on your PATH"; \
-	}
+	fi; \
+	export PATH="$(ARDUINO_CLI_BINDIR):$$PATH"; \
 	arduino-cli config add board_manager.additional_urls \
-		https://espressif.github.io/arduino-esp32/package_esp32_index.json || true
-	arduino-cli core update-index
-	arduino-cli core install esp32:esp32
+		https://espressif.github.io/arduino-esp32/package_esp32_index.json || true; \
+	arduino-cli core update-index; \
+	arduino-cli core install esp32:esp32; \
+	arduino-cli lib install \
+		"Adafruit GFX Library" \
+		"Adafruit ST7735 and ST7789 Library" \
+		"Adafruit NeoPixel" \
+		"Adafruit TestBed" \
+		"Button"
 
 ################################################################################
 ## Quality:: ##

--- a/server-esp32s3-rtft/Makefile
+++ b/server-esp32s3-rtft/Makefile
@@ -22,6 +22,8 @@ OPTS := USBMode=default,CDCOnBoot=cdc,PSRAM=enabled,PartitionScheme=tinyuf2,Flas
 PORT ?= /dev/ttyACM0
 SRC  := $(wildcard *.ino *.cpp *.h)
 ARDUINO_CLI_BINDIR ?= $(HOME)/.local/bin
+# Pinned: the firmware is near the DRAM limit; 3.3.10 overflows it by ~4 KB.
+ESP32_CORE := esp32:esp32@3.3.0
 
 ################################################################################
 ## General:: ##
@@ -55,7 +57,7 @@ require: ## install the toolchain (arduino-cli + core + libs)
 	arduino-cli config add board_manager.additional_urls \
 		https://espressif.github.io/arduino-esp32/package_esp32_index.json || true; \
 	arduino-cli core update-index; \
-	arduino-cli core install esp32:esp32; \
+	arduino-cli core install $(ESP32_CORE); \
 	arduino-cli lib install \
 		"Adafruit GFX Library" \
 		"Adafruit ST7735 and ST7789 Library" \


### PR DESCRIPTION
Adds a CI job that checks the firmware compiles — would have caught the esp32-core narrowing regression (#35).

- **`require`** (firmware Makefile): one PATH-robust shell block; now also `arduino-cli lib install`s the firmware's libs — Adafruit GFX, ST7735/ST7789, NeoPixel, TestBed, Button (BusIO + SdFat as deps).
- **`ci.yml`**: a `firmware-build` job — caches `~/.arduino15` + `~/Arduino`, then `make require` + `make firmware-build`.

Self-validating: watch this PR's `firmware-build` check (first run populates the cache, so it's the slow one).

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)