### PR TITLE
[impl] Top-level signpost Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Top-level signpost — this repository has no build of its own.
+# The work lives in the sub-projects, each with its own Makefile:
+#
+#   client-py/            Python client + app logic + the test suites
+#   server-esp32s3-rtft/  board firmware (build / flash via arduino-cli)
+#
+# Run 'make' here for this signpost; 'cd' into a sub-project and 'make help'.
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@echo "arduino-esp32-tft-terminal — no top-level build; work in the sub-projects:"
+	@echo
+	@echo "  client-py/            Python client, apps, and the test suites"
+	@echo "                          cd client-py && make help"
+	@echo "                          (tests live here: a running app drives the board)"
+	@echo
+	@echo "  server-esp32s3-rtft/  board firmware (build / flash via arduino-cli)"
+	@echo "                          cd server-esp32s3-rtft && make help"

--- a/devlog/0046-top-makefile.md
+++ b/devlog/0046-top-makefile.md
@@ -1,0 +1,54 @@
+# 0046 — Top-level signpost Makefile
+
+- GH issue: #46
+- Branch: impl/0046-top-makefile
+- Opened: 2026-06-27
+- Closed: 2026-06-27
+
+Fast-path task.
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+A repo-root `Makefile` that builds nothing; running `make` points to where the real work lives (the sub-makefiles), and hints that the tests are in `client-py/` (a running app is needed to drive the board).
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+`Makefile` with `.DEFAULT_GOAL := help`; `help` echoes the two sub-projects (`client-py/`, `server-esp32s3-rtft/`) and their `make help`, with the tests-live-in-client-py note. No build targets.
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 Verification
+
+- `make` (default goal) prints the signpost; no build is attempted.
+
+### 3.2 Verdict
+
+Accept.
+
+## Governance trace
+
+| Source                | Clause          | Action  | Note                                  |
+| --------------------- | --------------- | ------- | ------------------------------------- |
+| CLAUDE.md (Naming)    | outcome-named   | applied | root `make` = discoverability signpost |
+
+## Resource consumption
+
+| Phase | Tokens (approx) | Wall time |
+| ----- | --------------- | --------- |
+| Total | ~4k             | ~5 min    |
+
+| Counter       | Value |
+| ------------- | ----- |
+| Files changed | 2 (Makefile, devlog) |


### PR DESCRIPTION
TODO item 3. A repo-root `Makefile` that builds nothing — running `make` signposts the sub-makefiles.

```
arduino-esp32-tft-terminal — no top-level build; work in the sub-projects:

  client-py/            Python client, apps, and the test suites
                          cd client-py && make help
                          (tests live here: a running app drives the board)

  server-esp32s3-rtft/  board firmware (build / flash via arduino-cli)
                          cd server-esp32s3-rtft && make help
```

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)