### PR TITLE
[impl] Firmware: version command + CHANGES.md (client surfaces it)

### DIFF
--- a/client-py/src/arduino_esp32_tft_terminal/lib/board.py
+++ b/client-py/src/arduino_esp32_tft_terminal/lib/board.py
@@ -82,9 +82,14 @@ class Board:
             config.HEIGHT = h
             config.COLUMNS = int(w / 6.4)
             config.ROWS = int(h / 8)
+            try:
+                version = self.gfx._command('version')
+            except Exception:
+                version = 'unknown'  # older firmware without the command
             print('OLED resolution:')
             print(f'  pixels: {w} x {h}')
             print(f'  chars:  {config.COLUMNS} x {config.ROWS}')
+            print(f'firmware version: {version}')
 
         if self.configure_callback:
             self.configure_callback()

--- a/devlog/0048-fw-version.md
+++ b/devlog/0048-fw-version.md
@@ -1,0 +1,64 @@
+# 0048 — Firmware: version command + CHANGES.md (build-injected)
+
+- GH issue: #48
+- Branch: impl/0048-fw-version
+- Opened: 2026-06-27
+- Closed: 2026-06-27
+
+Fast-path task. Flashed as its own checkpoint (before the riskier DRAM trim).
+
+## 1. Mandate
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+Add a board `version` command returning the firmware version, maintained in a firmware `CHANGES.md` (same `## Version X.Y.Z:` format as `client-py/`) and injected at build time.
+
+## 2. Execution plan
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+1. `server-esp32s3-rtft/CHANGES.md` — `## Version 0.1.0:`.
+2. Makefile: `version.h` generated from CHANGES.md (`#define FW_VERSION`); `firmware-build` depends on it; `version.h` excluded from `SRC` (format) and git-ignored.
+3. `command.cpp`: `#include "version.h"` + `case hash("version"): return FW_VERSION;`.
+4. Client: on connect (`board._configure`), print the firmware version alongside the resolution. Query the new command with a try/except fallback to `unknown` for older firmware.
+
+## 3. Closure
+
+- Author: agent
+- Model: Claude Opus 4.8
+- Review: pending
+
+### 3.1 Verification
+
+- Build: `version.h` → `FW_VERSION "0.1.0"`; compiles 498187 bytes flash, **278336 globals (DRAM unchanged** — the string lives in flash). `format-check` clean.
+- **Hardware-verified** (after a flash-recovery detour, see Notes): via `client-py`, the board answers `width 240`, `height 135`, **`version 0.1.0`**.
+- Client on connect now prints `firmware version: 0.1.0` under the resolution (hardware-confirmed). Host suite: ruff clean, 24 tests pass.
+
+### 3.2 Notes — flash recovery
+
+- The first esptool flash hit "chip stopped responding" mid-write, leaving a partial app → the board fell into a reboot loop / tinyuf2 disk mode. Recovered by entering **ROM download mode** (hold BOOT, tap RESET) and re-flashing — completed cleanly. Then a physical RESET booted the app.
+- Verification must use `client-py` (which handles the reset/READY handshake), not raw pyserial — opening the CDC port with DTR asserted re-triggers the bootloader.
+
+### 3.3 Verdict
+
+Accept.
+
+## Governance trace
+
+| Source                  | Clause            | Action  | Note                                      |
+| ----------------------- | ----------------- | ------- | ----------------------------------------- |
+| CLAUDE.md (consistency) | shared versioning | applied | firmware version maintained like client-py |
+
+## Resource consumption
+
+| Phase | Tokens (approx) | Wall time |
+| ----- | --------------- | --------- |
+| Total | ~16k            | ~25 min   |
+
+| Counter       | Value |
+| ------------- | ----- |
+| Files changed | 5 (CHANGES.md, .gitignore, Makefile, command.cpp, devlog) |

--- a/server-esp32s3-rtft/.gitignore
+++ b/server-esp32s3-rtft/.gitignore
@@ -1,0 +1,5 @@
+# Generated at build time from CHANGES.md
+version.h
+
+# arduino-cli build output (see .vscode/arduino.json "output")
+/build/

--- a/server-esp32s3-rtft/CHANGES.md
+++ b/server-esp32s3-rtft/CHANGES.md
@@ -1,0 +1,5 @@
+# Changes
+
+## Version 0.1.0:
+
+- First versioned firmware release; adds the `version` command.

--- a/server-esp32s3-rtft/Makefile
+++ b/server-esp32s3-rtft/Makefile
@@ -20,7 +20,8 @@ FQBN := esp32:esp32:adafruit_feather_esp32s3_reversetft
 # Key board options (the full set lives in .vscode/arduino.json).
 OPTS := USBMode=default,CDCOnBoot=cdc,PSRAM=enabled,PartitionScheme=tinyuf2,FlashSize=4M
 PORT ?= /dev/ttyACM0
-SRC  := $(wildcard *.ino *.cpp *.h)
+# version.h is generated from CHANGES.md (see below) — excluded from formatting.
+SRC  := $(filter-out version.h,$(wildcard *.ino *.cpp *.h))
 ARDUINO_CLI_BINDIR ?= $(HOME)/.local/bin
 # Pinned: the firmware is near the DRAM limit; 3.3.10 overflows it by ~4 KB.
 ESP32_CORE := esp32:esp32@3.3.0
@@ -79,8 +80,15 @@ format-check: ## check formatting (read-only)
 ################################################################################
 ## Build and flash:: ##
 
+# Generated so the firmware can report its version (the `version` command).
+version.h: CHANGES.md
+	@V=$$(awk -F'[ :]' '/^## Version / {print $$3; exit}' CHANGES.md); \
+	if [ -z "$$V" ]; then echo "version.h: no version in CHANGES.md" >&2; exit 1; fi; \
+	printf '// generated from CHANGES.md by make — do not edit\n#define FW_VERSION "%s"\n' "$$V" > version.h; \
+	echo "version.h: FW_VERSION=$$V"
+
 .PHONY: firmware-build
-firmware-build: ## compile the sketch (arduino-cli)
+firmware-build: version.h ## compile the sketch (arduino-cli)
 	arduino-cli compile -b "$(FQBN):$(OPTS)" .
 
 .PHONY: firmware-upload

--- a/server-esp32s3-rtft/command.cpp
+++ b/server-esp32s3-rtft/command.cpp
@@ -8,6 +8,7 @@
 #include "config.h"
 #include "esp32s3-display.h"
 #include "transaction.h"
+#include "version.h"  // generated: FW_VERSION
 
 // constants
 const char *ERR_EXTRA_ARG = "ERROR extra arg";
@@ -102,6 +103,12 @@ const char *interpret(char *input, const Config &config) {
         case hash("reboot"): {  // reboot
             rebootF();
             return ok();
+        }
+
+        case hash("version"): {  // version
+            no_arg(&rest, error);
+            if (error.message) return error.message;
+            return FW_VERSION;
         }
 
         case hash("autoDisplay"): {  // autoDisplay 1


### PR DESCRIPTION
TODO item 1. A board `version` command + firmware version maintained in `CHANGES.md`, build-injected; the client prints it on connect.

- `server-esp32s3-rtft/CHANGES.md` — `## Version 0.1.0:`.
- Makefile generates `version.h` (`#define FW_VERSION`) from CHANGES.md; `firmware-build` depends on it; `version.h` git-ignored + excluded from `SRC`.
- `command.cpp` — `case hash("version"): return FW_VERSION;`.
- Client `board._configure` prints `firmware version: X` under the resolution (queries the command; `unknown` fallback for older firmware).

**Hardware-verified** (the board was recovered via ROM download mode after an interrupted flash, see devlog): the board answers `version 0.1.0` and the client prints it. DRAM unchanged (the string is in flash). ruff clean, 24 tests pass.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)